### PR TITLE
style: thin timeline — circle+line markers, arrow playhead, narrow index rows

### DIFF
--- a/src/components/thin/MarkersTrack.css
+++ b/src/components/thin/MarkersTrack.css
@@ -2,27 +2,67 @@
   cursor: copy;
 }
 
+/* Warp markers read as a small circle with a vertical line running through it.
+ * Button itself is a transparent hit target; ::before draws the line and
+ * ::after draws the circle glyph centered on the anchor time. */
 .thin-marker {
   position: absolute;
-  top: 2px;
-  bottom: 2px;
-  width: 3px;
+  top: 0;
+  bottom: 0;
+  width: 12px;
   padding: 0;
   transform: translateX(-50%);
-  background: hsl(195, 75%, 60%);
+  background: transparent;
   border: none;
-  border-radius: 1px;
   cursor: pointer;
-  transition: background 0.08s, box-shadow 0.08s, transform 0.08s;
 }
 
-.thin-marker:hover {
+.thin-marker::before {
+  content: '';
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  left: 50%;
+  width: 1.5px;
+  transform: translateX(-50%);
+  background: hsl(195, 75%, 60%);
+  transition: background 0.08s, width 0.08s;
+}
+
+.thin-marker::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 7px;
+  height: 7px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: hsl(195, 75%, 60%);
+  border: 1.5px solid hsl(195, 85%, 72%);
+  box-sizing: border-box;
+  transition: background 0.08s, border-color 0.08s, box-shadow 0.08s, transform 0.08s;
+}
+
+.thin-marker:hover::before {
   background: hsl(195, 95%, 72%);
-  box-shadow: 0 0 4px hsla(195, 95%, 70%, 0.85);
+  width: 2px;
 }
 
-.thin-marker--selected {
+.thin-marker:hover::after {
+  background: hsl(195, 95%, 72%);
+  border-color: hsl(195, 100%, 85%);
+  box-shadow: 0 0 5px hsla(195, 95%, 70%, 0.85);
+}
+
+.thin-marker--selected::before {
   background: hsl(48, 100%, 70%);
+  width: 2px;
+}
+
+.thin-marker--selected::after {
+  background: hsl(48, 100%, 70%);
+  border-color: hsl(48, 100%, 85%);
   box-shadow: 0 0 6px hsla(48, 100%, 65%, 0.9);
-  transform: translateX(-50%) scaleX(1.4);
+  transform: translate(-50%, -50%) scale(1.15);
 }

--- a/src/components/thin/ThinRuler.css
+++ b/src/components/thin/ThinRuler.css
@@ -16,6 +16,18 @@
   pointer-events: none;
 }
 
+/* Minor ticks — 5 subdivisions per labeled step. Sit at the bottom edge
+ * of the ruler so they read as hashes without competing with the labels. */
+.thin-ruler__minor-tick {
+  position: absolute;
+  bottom: 0;
+  height: 4px;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .thin-ruler__label {
   position: absolute;
   top: 2px;

--- a/src/components/thin/ThinRuler.tsx
+++ b/src/components/thin/ThinRuler.tsx
@@ -21,19 +21,30 @@ const SCRUB_HEADROOM = 0.001
  * rail so labels line up with the tracks below.
  */
 export default function ThinRuler({ view, duration, playhead, label = 'Time', onSeek }: ThinRulerProps) {
-  const ticks = useMemo(() => {
+  const { ticks, minorTicks } = useMemo(() => {
     const span = view.end - view.start
-    if (span <= 0) return []
+    if (span <= 0) return { ticks: [], minorTicks: [] as number[] }
     // Aim for ~8 labels across the width. Step snaps to a nice value.
     const raw = span / 8
     const niceSteps = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
     const step = niceSteps.find(s => s >= raw) ?? 600
     const first = Math.ceil(view.start / step) * step
-    const out: { time: number; label: string }[] = []
+    const ticks: { time: number; label: string }[] = []
     for (let t = first; t <= Math.min(view.end, duration) + 1e-6; t += step) {
-      out.push({ time: t, label: formatTime(t) })
+      ticks.push({ time: t, label: formatTime(t) })
     }
-    return out
+    // Minor ticks — 5 subdivisions per major step. Skipped positions that
+    // coincide with majors so ticks don't double-paint. Iterate by integer
+    // counter rather than floating-point += to avoid drift across many steps.
+    const minorStep = step / 5
+    const firstMinorIdx = Math.ceil(view.start / minorStep)
+    const lastMinorIdx = Math.floor(Math.min(view.end, duration) / minorStep)
+    const minorTicks: number[] = []
+    for (let i = firstMinorIdx; i <= lastMinorIdx; i++) {
+      if (i % 5 === 0) continue
+      minorTicks.push(i * minorStep)
+    }
+    return { ticks, minorTicks }
   }, [view.start, view.end, duration])
 
   const bodyRef = useRef<HTMLElement | null>(null)
@@ -73,6 +84,13 @@ export default function ThinRuler({ view, duration, playhead, label = 'Time', on
       onBackgroundClick={handleBgClick}
       onBackgroundPointerDown={handlePointerDown}
     >
+      {minorTicks.map((t, i) => {
+        const x = timeToViewPct(t, view)
+        if (x < -1 || x > 101) return null
+        return (
+          <span key={`m-${i}`} className="thin-ruler__minor-tick" style={{ left: `${x}%` }} />
+        )
+      })}
       {ticks.map((t, i) => {
         const x = timeToViewPct(t.time, view)
         if (x < -1 || x > 101) return null

--- a/src/components/thin/ThinTimeline.css
+++ b/src/components/thin/ThinTimeline.css
@@ -107,6 +107,42 @@
   height: 100%;
 }
 
+/* Subtle diagonal-stripe texture on the marker-in / warp / marker-out rows —
+ * makes the three tracks read as a related "warp stack" even without labels,
+ * and gives the eye something to land on when the rows grow tall. Stripes
+ * run the opposite direction on the input vs output bands (visually echoing
+ * the warp connector's slant direction at rest) and the warp row uses a
+ * different hue so it remains the visual centerpiece. */
+.thin-timeline__section[data-section="markerin"] .thin-row--markers .thin-row__body {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0,
+    transparent 5px,
+    hsla(195, 55%, 60%, 0.07) 5px,
+    hsla(195, 55%, 60%, 0.07) 6px
+  );
+}
+
+.thin-timeline__section[data-section="markerout"] .thin-row--markers .thin-row__body {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0,
+    transparent 5px,
+    hsla(280, 55%, 65%, 0.07) 5px,
+    hsla(280, 55%, 65%, 0.07) 6px
+  );
+}
+
+.thin-timeline__section[data-section="warp"] .warp-connector {
+  background-image: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 9px,
+    hsla(220, 40%, 65%, 0.05) 9px,
+    hsla(220, 40%, 65%, 0.05) 10px
+  );
+}
+
 .thin-row__rail--inline {
   height: auto;
   min-height: var(--thin-row-h);
@@ -165,6 +201,30 @@
   fill: none;
   stroke: hsla(0, 90%, 65%, 0.85);
   stroke-width: 1;
+}
+
+/* Downward-pointing arrowhead sitting at the top of the playhead line.
+ * Classic NLE look — bulk of the triangle sits inside the Time row, apex
+ * points down at the playhead's exact time. */
+.thin-timeline__playhead-arrow-layer {
+  position: absolute;
+  left: var(--thin-rail-w);
+  right: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: 6;
+}
+
+.thin-timeline__playhead-arrow {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid hsl(0, 90%, 65%);
+  filter: drop-shadow(0 0 2px hsla(0, 90%, 65%, 0.55));
 }
 
 .thin-timeline__hover {

--- a/src/components/thin/ThinTimeline.tsx
+++ b/src/components/thin/ThinTimeline.tsx
@@ -110,9 +110,14 @@ interface ThinTimelineProps {
   onToggleWarp?: () => void
 }
 
+// Rows where flex-grow is 0 stay pinned to their flex-basis (--thin-row-h)
+// as the timeline expands — scenes, clip-out, and speed read as thin index
+// strips that don't need extra vertical room. Users can still drag the
+// resizer grip to grow them manually; the resizer re-proportions flex on
+// drag so a 0-grow row can become non-zero if pulled open.
 const DEFAULT_FLEX: Record<string, number> = {
-  time: 1, clipin: 1, scenes: 1, thumbs: 1, markerin: 1,
-  warp: 1, markerout: 1, clipout: 1, beat: 1, speed: 1,
+  time: 1, clipin: 1, scenes: 0, thumbs: 1, markerin: 1,
+  warp: 1, markerout: 1, clipout: 0, beat: 1, speed: 0,
 }
 
 type SectionSpace = 'input' | 'output' | 'warp'
@@ -1136,6 +1141,23 @@ export default function ThinTimeline({
           {renderGlobalPlayhead()}
           {renderGlobalHoverCursor()}
         </svg>
+      )}
+
+      {/* Down-pointing playhead arrow above the Time ruler — classic NLE/DAW
+       *  look. The arrow sits at the top of the first section; its point
+       *  marks the playhead time, and the stroke from the SVG overlay picks
+       *  up below it. Non-scaling CSS triangle keeps crisp edges regardless
+       *  of viewport width. */}
+      {playheadInX !== null && layouts.length > 0 && (
+        <div
+          className="thin-timeline__playhead-arrow-layer"
+          style={{ top: `${overlayTop}px` }}
+        >
+          <div
+            className="thin-timeline__playhead-arrow"
+            style={{ left: `${playheadInX}%` }}
+          />
+        </div>
       )}
 
       <div className="thin-timeline__toolbar">


### PR DESCRIPTION
## Summary
- Warp markers restyled as a small circle with a vertical line through it (pseudo-elements on a 12px transparent hit target — hover grows the line, selected colors it yellow and scales the circle).
- Playhead gets a classic downward-pointing arrowhead at the top of the Time ruler. The continuous stroke from the global SVG overlay picks up below it.
- `DEFAULT_FLEX` is 0 for `scenes`, `clipout`, and `speed` so those index strips stay pinned to one row when the timeline grows. The resizer grip still lets the user drag them open manually.
- Time ruler grows minor ticks (5 subdivisions per labeled step) along the bottom edge; skips positions that already hold a major tick.
- Marker-in / warp / marker-out rows gain a faint diagonal-stripe background (opposite slants on in vs out, different hue on warp) so the three read as a related stack when the rows are tall.

## Test plan
- [ ] `npm run tauri dev` — check the Time ruler shows new minor ticks, warp markers show as circle+line, playhead has a down-arrow at the top
- [ ] Resize the whole timeline panel — `scenes`, `clipout`, `speed` rows stay at one row's height while `markerin` / `warp` / `markerout` / `beat` grow
- [ ] Drag the resizer between any narrow row and its neighbor — narrow rows can still be pulled open manually
- [ ] Hover + select warp markers — the circle brightens on hover, goes yellow-gold when selected
- [ ] Scrub — playhead arrow + stroke track together, arrow sits at the top of the ruler

🤖 Generated with [Claude Code](https://claude.com/claude-code)