### PR TITLE
rife: batch interpolation via -M manifest (one process per export)

### DIFF
--- a/scripts/setup-binaries.mjs
+++ b/scripts/setup-binaries.mjs
@@ -20,9 +20,10 @@ const BIN_DIR = join(ROOT, 'src-tauri', 'binaries')
 const FF_VERSION = '6.1'
 const FF_BASE    = `https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v${FF_VERSION}`
 
-// rife-ncnn-vulkan release bundles every model — we only keep the binary + rife-v4.6.
-const RIFE_VERSION = '20221029'
-const RIFE_BASE    = `https://github.com/nihui/rife-ncnn-vulkan/releases/download/${RIFE_VERSION}`
+// rife-ncnn-vulkan from the aprowe fork — adds `-M manifest.json` batch mode.
+// Release bundles every model — we only keep the binary + rife-v4.6.
+const RIFE_VERSION = '20260422'
+const RIFE_BASE    = `https://github.com/aprowe/rife-ncnn-vulkan/releases/download/${RIFE_VERSION}`
 const RIFE_MODEL   = 'rife-v4.6'
 
 function targetTriple() {
@@ -43,7 +44,13 @@ function ffZipUrl(tool) {
 function rifeZipUrl() {
   const p = process.platform
   if (p === 'win32')  return `${RIFE_BASE}/rife-ncnn-vulkan-${RIFE_VERSION}-windows.zip`
-  if (p === 'darwin') return `${RIFE_BASE}/rife-ncnn-vulkan-${RIFE_VERSION}-macos.zip`
+  if (p === 'darwin') {
+    throw new Error(
+      `macOS prebuilts aren't published for aprowe/rife-ncnn-vulkan ${RIFE_VERSION}. ` +
+      `Build from source at https://github.com/aprowe/rife-ncnn-vulkan and drop the ` +
+      `binary + ${RIFE_MODEL}/ into src-tauri/binaries/, or run with RIFE_SKIP=1.`
+    )
+  }
   return `${RIFE_BASE}/rife-ncnn-vulkan-${RIFE_VERSION}-ubuntu.zip`
 }
 

--- a/src-tauri/src/rife.rs
+++ b/src-tauri/src/rife.rs
@@ -1,19 +1,14 @@
-//! RIFE frame interpolation via the rife-ncnn-vulkan standalone binary.
+//! Warp-aware RIFE frame interpolation via the rife-ncnn-vulkan standalone
+//! binary (aprowe fork — adds `-M manifest.json` batch mode).
 //!
-//! The binary is bundled as a sidecar under src-tauri/binaries/ with the
-//! rife-v4.6 model folder alongside it. See scripts/setup-binaries.mjs.
-//!
-//! Two entry points:
-//!
-//! `interpolate_rife` — legacy uniform-timestep pass over a pre-rendered video.
-//! Kept for non-warp interpolation (constant-speed fps up-conversion).
-//!
-//! `interpolate_rife_warped` — warp-aware. Given the piecewise-linear time_map
-//! (t_src → t_out) and a target fps, produces each output frame at the exact
-//! t_src position dictated by the warp: bracketing source frames A, B plus
-//! α = (idx - floor(idx)), fed to rife with `-s α` per pair. Output is silent;
-//! caller muxes the retimed audio track.
+//! Entry point: `interpolate_rife_warped`. Given the piecewise-linear time_map
+//! (t_src → t_out) and a target fps, it decides for each output frame whether
+//! to copy a source frame (degenerate or scene-cut bracket) or to interpolate.
+//! All interpolation entries are packed into a single manifest and fed to
+//! rife-ncnn-vulkan in ONE invocation — previously we spawned rife once per
+//! frame, which paid model-load + vulkan-init overhead for every single frame.
 
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
@@ -27,8 +22,6 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 const MODEL_NAME: &str = "rife-v4.6";
 
-/// Locate (rife-ncnn-vulkan exe, rife-v4.6 model dir).
-/// Prefers a sidecar next to the running executable, falls back to PATH.
 fn find_rife() -> Result<(String, PathBuf), String> {
     let mut search_dirs: Vec<PathBuf> = Vec::new();
 
@@ -38,11 +31,9 @@ fn find_rife() -> Result<(String, PathBuf), String> {
         }
     }
 
-    // Dev-mode: src-tauri/binaries/ relative to CARGO_MANIFEST_DIR.
     if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
         search_dirs.push(PathBuf::from(&manifest).join("binaries"));
     }
-    // Fallback relative to cwd for tests invoked from repo root.
     search_dirs.push(PathBuf::from("src-tauri").join("binaries"));
 
     #[cfg(target_os = "windows")]
@@ -78,7 +69,6 @@ fn find_rife() -> Result<(String, PathBuf), String> {
     ))
 }
 
-/// Read source fps using ffprobe (r_frame_rate).
 fn source_fps(input: &str) -> Result<f64, String> {
     let info = ffprobe_json(input)?;
     let streams = info["streams"].as_array().ok_or("ffprobe: no streams")?;
@@ -96,88 +86,6 @@ fn source_fps(input: &str) -> Result<f64, String> {
     Ok(num / den)
 }
 
-/// Run rife-ncnn-vulkan with a specific timestep. Produces one interleaved
-/// [src, interp] frame pair per consecutive source pair in `out_dir`.
-fn run_rife_timestep(
-    exe: &str,
-    src_dir: &Path,
-    out_dir: &Path,
-    model_dir: &Path,
-    timestep: f64,
-) -> Result<(), String> {
-    let src = src_dir.to_string_lossy().into_owned();
-    let out = out_dir.to_string_lossy().into_owned();
-    let model = model_dir.to_string_lossy().into_owned();
-    let ts = format!("{timestep:.6}");
-
-    let mut cmd = Command::new(exe);
-    cmd.args(["-i", &src, "-o", &out, "-s", &ts, "-m", &model, "-g", "1"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
-    #[cfg(target_os = "windows")]
-    cmd.creation_flags(CREATE_NO_WINDOW);
-
-    let output = cmd
-        .output()
-        .map_err(|e| format!("rife-ncnn-vulkan failed to spawn: {e}"))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "rife-ncnn-vulkan exited with status {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-                .last()
-                .unwrap_or("unknown error")
-        ));
-    }
-    Ok(())
-}
-
-/// Run rife-ncnn-vulkan in two-file mode at a specific α, producing exactly
-/// one interpolated frame between `a_png` and `b_png`. Unlike directory mode
-/// (`-i`/`-o`), the two-file mode (`-0`/`-1`) actually honors `-s` — in
-/// directory mode it is silently ignored and every pair is interpolated at α=0.5.
-fn run_rife_pair(
-    exe: &str,
-    a_png: &Path,
-    b_png: &Path,
-    out_png: &Path,
-    model_dir: &Path,
-    alpha: f64,
-) -> Result<(), String> {
-    let a = a_png.to_string_lossy().into_owned();
-    let b = b_png.to_string_lossy().into_owned();
-    let o = out_png.to_string_lossy().into_owned();
-    let model = model_dir.to_string_lossy().into_owned();
-    let ts = format!("{alpha:.6}");
-
-    let mut cmd = Command::new(exe);
-    cmd.args(["-0", &a, "-1", &b, "-o", &o, "-s", &ts, "-m", &model, "-g", "1"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
-    #[cfg(target_os = "windows")]
-    cmd.creation_flags(CREATE_NO_WINDOW);
-
-    let output = cmd
-        .output()
-        .map_err(|e| format!("rife-ncnn-vulkan failed to spawn: {e}"))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "rife-ncnn-vulkan (pair, α={alpha:.4}) exited with status {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-                .last()
-                .unwrap_or("unknown error")
-        ));
-    }
-    Ok(())
-}
-
 fn list_pngs(dir: &Path) -> Result<Vec<PathBuf>, String> {
     let mut frames: Vec<PathBuf> = std::fs::read_dir(dir)
         .map_err(|e| format!("read_dir {}: {e}", dir.display()))?
@@ -189,156 +97,82 @@ fn list_pngs(dir: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(frames)
 }
 
-/// Interpolate `input` to a constant `target_fps` using RIFE. Output includes audio.
-pub fn interpolate_rife<F>(
-    input: &str,
-    target_fps: u32,
-    output: &str,
+/// Spawn rife-ncnn-vulkan in manifest mode and stream its stderr, forwarding
+/// `progress N/total` lines to the caller.
+fn run_rife_manifest<F>(
+    exe: &str,
+    src_dir: &Path,
+    out_dir: &Path,
+    model_dir: &Path,
+    manifest_path: &Path,
+    total: usize,
+    progress_start: f64,
+    progress_end: f64,
     progress: &F,
 ) -> Result<(), String>
 where
     F: Fn(f64, &str) + Send,
 {
-    let (exe, model_dir) = find_rife()?;
-    progress(0.02, "Probing source fps...");
+    let src = src_dir.to_string_lossy().into_owned();
+    let out = out_dir.to_string_lossy().into_owned();
+    let model = model_dir.to_string_lossy().into_owned();
+    let manifest = manifest_path.to_string_lossy().into_owned();
 
-    let src_fps = source_fps(input)?;
-    if src_fps <= 0.0 {
-        return Err("source fps <= 0".into());
-    }
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "-i", &src,
+        "-o", &out,
+        "-M", &manifest,
+        "-m", &model,
+        "-g", "1",
+    ])
+    .stdout(Stdio::null())
+    .stderr(Stdio::piped());
+    #[cfg(target_os = "windows")]
+    cmd.creation_flags(CREATE_NO_WINDOW);
 
-    // Multiplier: at least 2x, integer, round target/src. Final fps resampling
-    // to exact target_fps happens at encode.
-    let multiplier: u32 = ((target_fps as f64 / src_fps).round() as i64).max(2) as u32;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("rife-ncnn-vulkan failed to spawn: {e}"))?;
 
-    let tmp = TempDir::new().map_err(|e| format!("tempdir: {e}"))?;
-    let src_dir = tmp.path().join("src");
-    std::fs::create_dir(&src_dir).map_err(|e| e.to_string())?;
-
-    progress(0.05, "Extracting source frames...");
-    run_ffmpeg(&[
-        "-y", "-hide_banner", "-loglevel", "error",
-        "-i", input,
-        &src_dir.join("%08d.png").to_string_lossy(),
-    ])?;
-
-    let src_frames = list_pngs(&src_dir)?;
-    if src_frames.len() < 2 {
-        return Err(format!(
-            "need ≥2 source frames to interpolate, got {}",
-            src_frames.len()
-        ));
-    }
-    let n_pairs = src_frames.len() - 1;
-    let expected_interleaved = 2 * (n_pairs + 1);
-
-    // One rife pass per intermediate timestep.
-    let timesteps: Vec<f64> = (1..multiplier)
-        .map(|k| k as f64 / multiplier as f64)
-        .collect();
-
-    let rife_start = 0.15;
-    let rife_end = 0.82;
-    let mut interp_by_ts: Vec<Vec<PathBuf>> = Vec::with_capacity(timesteps.len());
-
-    for (i, &t) in timesteps.iter().enumerate() {
-        let out_dir = tmp.path().join(format!("ts_{i}"));
-        std::fs::create_dir(&out_dir).map_err(|e| e.to_string())?;
-
-        progress(
-            rife_start + i as f64 / timesteps.len() as f64 * (rife_end - rife_start),
-            &format!("RIFE pass {}/{} (t={:.3})", i + 1, timesteps.len(), t),
-        );
-
-        run_rife_timestep(&exe, &src_dir, &out_dir, &model_dir, t)?;
-
-        let mut frames = list_pngs(&out_dir)?;
-        if frames.len() == expected_interleaved {
-            // [src_0, interp_01, src_1, interp_12, ..., src_N-1, src_N-1_dup]
-            // Keep odd indices (interp slots), drop the trailing duplicate.
-            frames = frames
-                .into_iter()
-                .enumerate()
-                .filter(|(idx, _)| idx % 2 == 1)
-                .map(|(_, p)| p)
-                .take(n_pairs)
-                .collect();
-        } else if frames.len() != n_pairs {
-            return Err(format!(
-                "rife pass t={t:.3}: expected {n_pairs} frames, got {}",
-                frames.len()
-            ));
-        }
-        interp_by_ts.push(frames);
-    }
-
-    progress(rife_end, "Interleaving frames...");
-
-    // Interleave into time order: [src_i, ts0_i, ts1_i, ..., src_{i+1}, ...].
-    let final_dir = tmp.path().join("final");
-    std::fs::create_dir(&final_dir).map_err(|e| e.to_string())?;
-    let mut out_idx: u64 = 1;
-    for (pair_idx, src) in src_frames.iter().enumerate() {
-        let dest = final_dir.join(format!("frame_{out_idx:08}.png"));
-        std::fs::copy(src, &dest).map_err(|e| e.to_string())?;
-        out_idx += 1;
-        if pair_idx < n_pairs {
-            for ts_frames in &interp_by_ts {
-                if let Some(f) = ts_frames.get(pair_idx) {
-                    let dest = final_dir.join(format!("frame_{out_idx:08}.png"));
-                    std::fs::copy(f, &dest).map_err(|e| e.to_string())?;
-                    out_idx += 1;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "rife-ncnn-vulkan stderr unavailable".to_string())?;
+    let reader = BufReader::new(stderr);
+    let mut last_error_line = String::new();
+    for line in reader.lines().map_while(Result::ok) {
+        if let Some(rest) = line.strip_prefix("progress ") {
+            if let Some((done_str, _)) = rest.split_once('/') {
+                if let Ok(done) = done_str.parse::<usize>() {
+                    let frac = if total == 0 {
+                        1.0
+                    } else {
+                        (done as f64 / total as f64).clamp(0.0, 1.0)
+                    };
+                    progress(
+                        progress_start + frac * (progress_end - progress_start),
+                        &format!("RIFE frame {done}/{total}"),
+                    );
                 }
             }
+        } else if !line.trim().is_empty() {
+            last_error_line = line;
         }
     }
 
-    progress(0.85, "Encoding + muxing...");
-
-    let achieved_fps = src_fps * multiplier as f64;
-    let pattern = final_dir.join("frame_%08d.png").to_string_lossy().into_owned();
-    let noaudio = tmp.path().join("noaudio.mp4").to_string_lossy().into_owned();
-    let vf = format!("fps={target_fps}");
-
-    // Encode RIFE frames at the achieved fps, resampling to exact target_fps.
-    let framerate = format!("{achieved_fps:.6}");
-    let target_r = target_fps.to_string();
-    run_ffmpeg(&[
-        "-y", "-hide_banner", "-loglevel", "error",
-        "-framerate", &framerate,
-        "-i", &pattern,
-        "-vf", &vf,
-        "-r", &target_r,
-        "-c:v", "libx264", "-preset", "fast", "-crf", "18",
-        "-pix_fmt", "yuv420p",
-        &noaudio,
-    ])?;
-
-    // Mux audio from the source. Use ? on the audio map so it's optional.
-    let mux_res = run_ffmpeg(&[
-        "-y", "-hide_banner", "-loglevel", "error",
-        "-i", &noaudio,
-        "-i", input,
-        "-map", "0:v:0",
-        "-map", "1:a:0?",
-        "-c:v", "copy",
-        "-c:a", "aac", "-b:a", "192k",
-        "-shortest",
-        output,
-    ]);
-    if mux_res.is_err() {
-        // No audio in source — just copy the video-only mp4.
-        std::fs::copy(&noaudio, output).map_err(|e| e.to_string())?;
+    let status = child
+        .wait()
+        .map_err(|e| format!("rife-ncnn-vulkan wait failed: {e}"))?;
+    if !status.success() {
+        return Err(format!(
+            "rife-ncnn-vulkan manifest exited with status {status}: {last_error_line}"
+        ));
     }
-
-    progress(1.0, "Done");
     Ok(())
 }
 
-// ── Warp-aware RIFE ──────────────────────────────────────────────────────────
-
 /// Invert the piecewise-linear time_map (t_src, t_out) at the given output time.
-/// Entries must be sorted by t_out (same as t_src since the map is monotonic).
 fn invert_time_map(time_map: &[(f64, f64)], t_out: f64) -> f64 {
     if time_map.is_empty() {
         return 0.0;
@@ -365,10 +199,17 @@ fn invert_time_map(time_map: &[(f64, f64)], t_out: f64) -> f64 {
     s0 + a * (s1 - s0)
 }
 
+enum Plan {
+    Copy(usize),
+    Interp(usize, f64),
+}
+
 /// Warp-aware RIFE. For each output frame at n/target_fps, computes t_src via
-/// the inverse time_map, finds bracketing source frames A, B, and runs rife
-/// once per pair with the exact α = frac(t_src * src_fps). Output has no audio —
-/// caller is expected to mux the retimed audio track from another source.
+/// the inverse time_map, finds bracketing source frames A, B, and emits either
+/// a held source frame (degenerate or scene-cut straddling) or an interpolated
+/// frame. All interpolations run through a single rife-ncnn-vulkan invocation
+/// using `-M manifest.json`. Output has no audio — caller muxes the retimed
+/// audio track.
 pub fn interpolate_rife_warped<F>(
     input: &str,
     time_map: &[(f64, f64)],
@@ -416,9 +257,6 @@ where
     let final_dir = tmp.path().join("final");
     std::fs::create_dir(&final_dir).map_err(|e| e.to_string())?;
 
-    let rife_start = 0.10;
-    let rife_end = 0.85;
-
     eprintln!(
         "[rife-warped] src_fps={src_fps:.4} target_fps={target_fps} n_out={n_out} \
          t_out_min={t_out_min:.6} t_out_max={t_out_max:.6} src_frames={}",
@@ -426,6 +264,7 @@ where
     );
     eprintln!("[rife-warped] frame_times: n | t_out | t_src | idx_f | a | b | alpha");
 
+    let mut plans: Vec<Plan> = Vec::with_capacity(n_out as usize);
     for n in 0..n_out {
         let t_out = t_out_min + n as f64 / target_fps as f64;
         let t_src = invert_time_map(time_map, t_out);
@@ -438,34 +277,85 @@ where
             "[rife-warped] {n:4} | t_out={t_out:.6} | t_src={t_src:.6} | idx_f={idx_f:.4} | a={a} | b={b} | α={alpha:.4}"
         );
 
-        let dest = final_dir.join(format!("frame_{:08}.png", n + 1));
-
-        // Two-file mode (-0/-1): required because rife-ncnn-vulkan silently
-        // ignores `-s` in directory mode and always produces α=0.5 frames there,
-        // which was the source of the "pair" artefact in the output.
         let t_a = a as f64 / src_fps;
         let t_b = b as f64 / src_fps;
         let straddles_cut = scene_cuts.iter().any(|&c| c > t_a && c <= t_b);
+
         if a == b {
-            // Degenerate: only one source frame available; just emit it.
-            std::fs::copy(&src_frames[a], &dest).map_err(|e| e.to_string())?;
+            plans.push(Plan::Copy(a));
         } else if straddles_cut {
-            // Don't blend across a hard cut — the two frames are unrelated and
-            // RIFE would melt them together. Hold the closer source frame.
-            let pick = if alpha < 0.5 { a } else { b };
-            std::fs::copy(&src_frames[pick], &dest).map_err(|e| e.to_string())?;
+            plans.push(Plan::Copy(if alpha < 0.5 { a } else { b }));
         } else {
-            // Clamp α to the open interval — rife-ncnn-vulkan is undefined at 0/1.
+            // rife rejects α=0 and α=1; clamp to the open interval.
             let alpha_clamped = alpha.max(1e-3).min(1.0 - 1e-3);
-            run_rife_pair(&exe, &src_frames[a], &src_frames[b], &dest, &model_dir, alpha_clamped)?;
+            plans.push(Plan::Interp(a, alpha_clamped));
+        }
+    }
+
+    let interp_plan_indices: Vec<usize> = plans
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| matches!(p, Plan::Interp(_, _)).then_some(i))
+        .collect();
+
+    let rife_start = 0.10;
+    let rife_end = 0.85;
+
+    if !interp_plan_indices.is_empty() {
+        let rife_out_dir = tmp.path().join("rife_out");
+        std::fs::create_dir(&rife_out_dir).map_err(|e| e.to_string())?;
+
+        // Manifest entries are 1-based: integer part = left source frame index + 1.
+        let manifest_body = {
+            let entries: Vec<String> = interp_plan_indices
+                .iter()
+                .map(|&i| match plans[i] {
+                    Plan::Interp(a, alpha) => format!("{:.6}", (a + 1) as f64 + alpha),
+                    _ => unreachable!(),
+                })
+                .collect();
+            format!("[{}]", entries.join(","))
+        };
+        let manifest_path = tmp.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest_body)
+            .map_err(|e| format!("write manifest: {e}"))?;
+
+        progress(
+            rife_start,
+            &format!("RIFE manifest: {} frames", interp_plan_indices.len()),
+        );
+
+        run_rife_manifest(
+            &exe,
+            &src_dir,
+            &rife_out_dir,
+            &model_dir,
+            &manifest_path,
+            interp_plan_indices.len(),
+            rife_start,
+            rife_end,
+            progress,
+        )?;
+
+        let rife_frames = list_pngs(&rife_out_dir)?;
+        if rife_frames.len() != interp_plan_indices.len() {
+            return Err(format!(
+                "rife manifest: expected {} frames, got {}",
+                interp_plan_indices.len(),
+                rife_frames.len()
+            ));
         }
 
-        if n % 8 == 0 || n + 1 == n_out {
-            let frac = (n + 1) as f64 / n_out as f64;
-            progress(
-                rife_start + frac * (rife_end - rife_start),
-                &format!("RIFE frame {}/{}", n + 1, n_out),
-            );
+        for (rife_idx, &plan_idx) in interp_plan_indices.iter().enumerate() {
+            let dest = final_dir.join(format!("frame_{:08}.png", plan_idx + 1));
+            std::fs::copy(&rife_frames[rife_idx], &dest).map_err(|e| e.to_string())?;
+        }
+    }
+
+    for (plan_idx, p) in plans.iter().enumerate() {
+        if let Plan::Copy(src_idx) = *p {
+            let dest = final_dir.join(format!("frame_{:08}.png", plan_idx + 1));
+            std::fs::copy(&src_frames[src_idx], &dest).map_err(|e| e.to_string())?;
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace per-frame rife-ncnn-vulkan invocations with a single manifest-mode call (`-M manifest.json`) using the aprowe fork
- Plan every output frame in Rust (copy vs interp, scene-cut bracketing, alpha clamping), pack interps into one manifest, invoke rife once
- Stream rife's stderr \`progress N/total\` lines for live progress updates instead of the old per-batch 8-frame ticker
- Drop now-dead helpers: legacy \`interpolate_rife\`, \`run_rife_timestep\`, \`run_rife_pair\`
- \`setup-binaries.mjs\` now pulls from \`aprowe/rife-ncnn-vulkan\` release \`20260422\` (the fork shipping \`-M\`)

### Why

The old \`interpolate_rife_warped\` spawned rife once per output frame in two-file mode (\`-0\`/\`-1\`), because directory mode silently ignores \`-s\`. Every spawn paid model-load + vulkan-init cost — dozens of ms up to seconds each, multiplied by hundreds-to-thousands of output frames. The fork's new \`-M\` mode reads an array of \`N.alpha\` entries and renders all pairs in one process with pipelined load/proc/save threads.

### Platform note

macOS prebuilds aren't published for the fork's \`20260422\` release yet (CI is disabled pending macos-13 runner availability). \`setup-binaries.mjs\` now errors out on darwin with a build-from-source hint; users can still set \`RIFE_SKIP=1\` to bypass.

## Test plan

- [ ] \`npm run setup\` (Windows) — confirms new binary downloads + unpacks \`rife-v4.6\`
- [ ] \`cargo test --test warp_e2e rife_method_produces_constant_target_fps_output -- --ignored\` — asserts constant-fps output unchanged
- [ ] Manual export with RIFE method — confirm \`progress N/total\` lines appear on stderr and UI progress bar advances smoothly
- [ ] Manual export across a scene cut — confirm held-frame behavior preserved (copy-not-interp at boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)