### PR TITLE
feat: export — pre-select timeline clips, skip RIFE on unwarped ones

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,7 @@ export default function App() {
     dispatch(updateRegionLockAction({ id, lock, lockedBeats }))
   const exportOpen = useAppSelector(s => s.ui.exportOpen)
   const setExportOpen = (v: boolean) => dispatch(setExportOpenAction(v))
+  const selectedClipIds = useAppSelector(s => s.lists.selection.clips)
   const [clipContextMenu, setClipContextMenu] = useState<ContextMenuState | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
   const [pendingZoom, setPendingZoom] = useState<{ start: number; end: number } | null>(null)
@@ -407,6 +408,7 @@ export default function App() {
         trimToLoop={trimToLoop}
         regions={regions}
         activeRegionId={activeRegionId}
+        selectedClipIds={selectedClipIds}
       />
       <ThumbnailPopup />
       <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -34,6 +34,10 @@ interface ExportDialogProps {
   trimToLoop: boolean
   regions: Region[]
   activeRegionId: string | null
+  /** Clip ids selected on the timeline / clips list. When the dialog opens
+   *  with a non-empty selection we auto-switch into 'selected' mode and
+   *  pre-check those ids, so "export selected" is one click. */
+  selectedClipIds?: readonly string[]
 }
 
 type ExportMode = 'current' | 'all' | 'selected'
@@ -104,6 +108,7 @@ function parentFolder(filePath: string): string {
 export default function ExportDialog({
   open, onClose, warpData, videoPath, originalName, videoFps,
   loopBeats, addToEnd, trimToLoop, regions, activeRegionId,
+  selectedClipIds,
 }: ExportDialogProps) {
   const [fadeAtLoop, setFadeAtLoop] = useState(false)
   const [normalizeBpm, setNormalizeBpm] = useState(false)
@@ -169,10 +174,22 @@ export default function ExportDialog({
       setCurrentMessage('')
       setLogLines([])
       cancelRef.current = false
-      setSelectedRegionIds(new Set(regions.map(r => r.id)))
+      // Prefer the timeline's clip selection when the dialog opens: switch
+      // into 'selected' mode and pre-check exactly those ids. Filter by the
+      // live regions list so stale ids can't end up in the checked set. If
+      // nothing is selected, fall back to the old default (every region
+      // checked, caller picks a mode).
+      const preSelected = (selectedClipIds ?? [])
+        .filter(id => regions.some(r => r.id === id))
+      if (preSelected.length > 0) {
+        setMode('selected')
+        setSelectedRegionIds(new Set(preSelected))
+      } else {
+        setSelectedRegionIds(new Set(regions.map(r => r.id)))
+      }
       setInterpFps(Math.round(videoFps ?? 60))
     }
-  }, [open, regions, videoFps]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, regions, videoFps, selectedClipIds]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => () => { unlistenRef.current?.() }, [])
 

--- a/src/utils/exportRequest.ts
+++ b/src/utils/exportRequest.ts
@@ -53,6 +53,15 @@ export function buildWarpRequest(input: BuildWarpRequestInput): WarpRequest {
 
   const triggerMode = !!job.triggerMode
   const cutsInRange = (sceneCuts ?? []).filter(inRange)
+  // RIFE is warp-aware — on a clip with no markers in range the time map is
+  // the identity, so RIFE is pure cost with no benefit. The user wants RIFE
+  // only on clips they actually warped, with no interpolation otherwise
+  // (not a minterpolate fallback). Minterpolate keeps applying to every
+  // clip the same as before.
+  const rifeOnUnwarped = interpolateFrames
+    && interpMethod === 'rife'
+    && pairs.length === 0
+  const useInterp = !triggerMode && interpolateFrames && !rifeOnUnwarped
   return {
     path: videoPath,
     orig_times: pairs.map(p => p.orig),
@@ -67,8 +76,8 @@ export function buildWarpRequest(input: BuildWarpRequestInput): WarpRequest {
     clip_in: job.clipIn ?? null,
     clip_out: job.clipOut ?? null,
     // Trigger mode plays at 1.0x; frame interpolation makes no sense there.
-    interp_fps: !triggerMode && interpolateFrames ? Math.max(1, Math.round(interpFps)) : null,
-    interp_method: !triggerMode && interpolateFrames ? interpMethod : null,
+    interp_fps: useInterp ? Math.max(1, Math.round(interpFps)) : null,
+    interp_method: useInterp ? interpMethod : null,
     trigger_mode: triggerMode,
     scene_cuts: cutsInRange,
   }

--- a/tests/unit/utils/exportRequest.test.ts
+++ b/tests/unit/utils/exportRequest.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { buildWarpRequest } from '../../../src/utils/exportRequest'
+import type { WarpData } from '../../../src/types'
+
+const warpDataWithMarkers: WarpData = {
+  origAnchors: [{ id: 1, time: 4 }, { id: 2, time: 12 }],
+  beatAnchors: [{ id: 1, time: 4 }, { id: 2, time: 13 }],
+  bpm: 120,
+  minStretch: 0.5,
+  maxStretch: 2.0,
+  beatZeroTime: 4,
+  addToEnd: false,
+}
+
+const baseInput = {
+  videoPath: '/videos/song.mp4',
+  loopBeats: null,
+  trimToLoop: false,
+  fadeAtLoop: false,
+  normalizeBpm: false,
+  interpolateFrames: true,
+  interpFps: 60,
+  sceneCuts: [],
+}
+
+describe('buildWarpRequest — RIFE skip on unwarped clips', () => {
+  it('passes RIFE through when the clip window contains markers', () => {
+    const req = buildWarpRequest({
+      ...baseInput,
+      warpData: warpDataWithMarkers,
+      interpMethod: 'rife',
+      job: { label: 'in-range', clipIn: 0, clipOut: 20, bpm: 120, addToEnd: false },
+    })
+    expect(req.interp_method).toBe('rife')
+    expect(req.interp_fps).toBe(60)
+    expect(req.orig_times.length).toBeGreaterThan(0)
+  })
+
+  it('drops RIFE entirely when the clip window has no markers', () => {
+    // Window is [20, 30]; markers are at 4 and 12 — none survive the filter.
+    const req = buildWarpRequest({
+      ...baseInput,
+      warpData: warpDataWithMarkers,
+      interpMethod: 'rife',
+      job: { label: 'out-of-range', clipIn: 20, clipOut: 30, bpm: 120, addToEnd: false },
+    })
+    expect(req.orig_times).toEqual([])
+    expect(req.interp_method).toBeNull()
+    expect(req.interp_fps).toBeNull()
+  })
+
+  it('drops RIFE on a video with no warpData at all', () => {
+    const req = buildWarpRequest({
+      ...baseInput,
+      warpData: null,
+      interpMethod: 'rife',
+      job: { label: 'raw', clipIn: null, clipOut: null, bpm: 120, addToEnd: false },
+    })
+    expect(req.orig_times).toEqual([])
+    expect(req.interp_method).toBeNull()
+    expect(req.interp_fps).toBeNull()
+  })
+
+  it('keeps minterpolate on an unwarped clip (gate is RIFE-only)', () => {
+    const req = buildWarpRequest({
+      ...baseInput,
+      warpData: warpDataWithMarkers,
+      interpMethod: 'minterpolate',
+      job: { label: 'out-of-range', clipIn: 20, clipOut: 30, bpm: 120, addToEnd: false },
+    })
+    expect(req.orig_times).toEqual([])
+    expect(req.interp_method).toBe('minterpolate')
+    expect(req.interp_fps).toBe(60)
+  })
+
+  it('does not interpolate when the user left the checkbox off', () => {
+    const req = buildWarpRequest({
+      ...baseInput,
+      warpData: warpDataWithMarkers,
+      interpolateFrames: false,
+      interpMethod: 'rife',
+      job: { label: 'in-range', clipIn: 0, clipOut: 20, bpm: 120, addToEnd: false },
+    })
+    expect(req.interp_method).toBeNull()
+    expect(req.interp_fps).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- `ExportDialog` accepts a new `selectedClipIds` prop. When the dialog opens with a non-empty timeline selection, it auto-switches to `selected` mode with exactly those ids pre-checked (filtered against the live regions list). No selection → old default (every region checked).
- `App.tsx` reads `state.lists.selection.clips` and forwards it.
- `buildWarpRequest` drops `interp_method` and `interp_fps` to null when the user picked **RIFE** and the clip's time window contains zero warp markers. On those clips the time map is the identity, so RIFE is pure cost for no benefit. Minterpolate still applies to every clip — the gate is RIFE-only, per the request.
- Unit tests cover in-range / out-of-range / no-warpData / minterpolate passthrough / interpolate-off escape hatch.

## Test plan
- [ ] Select two clips on the timeline → open Export → confirm the dialog lands on `Selected` mode with exactly those two checked
- [ ] Open Export with nothing selected → still defaults to `Current`, and the `Select` list has every region pre-checked (original behavior)
- [ ] Export All with RIFE + FPS → clips with markers get RIFE, clips with zero markers export with no interpolation (check the log — no "Running warp-aware RIFE" line for the unwarped clips)
- [ ] Export All with minterpolate + FPS → every clip still gets minterpolate, warped or not
- [ ] `rtk vitest run tests/unit/utils/exportRequest.test.ts` (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)