### PR TITLE
add top-level ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.css
+++ b/src/components/ErrorBoundary.css
@@ -1,0 +1,73 @@
+.error-boundary {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg-1, #1a1a1a);
+  color: var(--fg-1, #e5e5e5);
+  font-family: var(--font-family, system-ui, sans-serif);
+  z-index: 10000;
+  overflow: auto;
+}
+
+.error-boundary__card {
+  max-width: 900px;
+  width: 100%;
+  background: var(--bg-3, #2a2a2a);
+  border: 1px solid var(--border, #444);
+  border-radius: 8px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.error-boundary__title {
+  margin: 0;
+  font-size: 18px;
+  color: #ff8a8a;
+}
+
+.error-boundary__message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.error-boundary__stack {
+  margin: 0;
+  padding: 12px;
+  background: var(--bg-1, #111);
+  border: 1px solid var(--border, #333);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  max-height: 360px;
+  overflow: auto;
+  white-space: pre-wrap;
+  user-select: text;
+}
+
+.error-boundary__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.error-boundary__actions button {
+  padding: 8px 16px;
+  background: var(--bg-2, #333);
+  border: 1px solid var(--border-hi, #555);
+  border-radius: 4px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.error-boundary__actions button:hover {
+  background: var(--bg-3, #444);
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import './ErrorBoundary.css'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  error: Error | null
+  componentStack: string | null
+}
+
+/**
+ * Top-level error boundary. Without one, an uncaught render error unmounts the
+ * whole React tree in production and leaves the Tauri window showing nothing
+ * but the chrome — users read that as "app went fullscreen" / "frontend died".
+ *
+ * Hooks can't catch render errors, so this stays a class component.
+ */
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, componentStack: null }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Log to the console so production DevTools (or tauri log capture) can
+    // surface it alongside the fallback UI for copy/paste.
+    console.error('ErrorBoundary caught:', error, info.componentStack)
+    this.setState({ componentStack: info.componentStack ?? null })
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  handleReset = () => {
+    this.setState({ error: null, componentStack: null })
+  }
+
+  render() {
+    const { error, componentStack } = this.state
+    if (!error) return this.props.children
+
+    return (
+      <div className="error-boundary">
+        <div className="error-boundary__card">
+          <h1 className="error-boundary__title">Something broke</h1>
+          <p className="error-boundary__message">{error.message || String(error)}</p>
+          <pre className="error-boundary__stack">{error.stack ?? ''}{componentStack ?? ''}</pre>
+          <div className="error-boundary__actions">
+            <button type="button" onClick={this.handleReset}>Try again</button>
+            <button type="button" onClick={this.handleReload}>Reload app</button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,13 +5,16 @@ import { store } from './store/store'
 import { initUiScale } from './uiScale'
 import './index.css'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 
 initUiScale()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
+    <ErrorBoundary>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary

- Adds \`src/components/ErrorBoundary.tsx\` + \`.css\`
- Wraps the Provider in \`main.tsx\` so render errors in any subtree are caught
- Fallback UI shows the error message + stack (user-selectable) plus \"Try again\" / \"Reload app\" buttons

## Why

Release builds have no dev overlay — an uncaught render error silently unmounts the whole tree and the Tauri window shows only its chrome. Users read that as \"app went fullscreen\" or \"frontend died\" with no recovery short of restarting.

Known candidate triggers in-flight: switching the list thumbnail mode to \`always\` on some panels, and closing the export dialog. This PR doesn't fix the underlying bugs — it surfaces whichever error is actually being thrown so we can pinpoint the root cause on the next repro.

## Test plan

- [ ] Install and reproduce either bug in a release build; the fallback card should now appear with the exact error message + stack
- [ ] \"Try again\" resets the boundary state and re-mounts children
- [ ] \"Reload app\" triggers \`window.location.reload()\`
- [ ] Happy path: no regression in normal usage (boundary is inert when no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)