### PR TITLE
feat(player): experimental snappy canvas player fed by ffmpeg MJPEG stream

### DIFF
--- a/docs/SNAPPY_PLAYER_NOTES.md
+++ b/docs/SNAPPY_PLAYER_NOTES.md
@@ -1,0 +1,138 @@
+# Snappy player (experimental)
+
+A prototype canvas-based video player that replaces the HTML5 `<video>`
+element with an ffmpeg-fed frame stream rendered to a 2D canvas. Goal: make
+scrub feel instant by paying the decode cost once, in advance, around the
+playhead.
+
+Off by default. Toggle on in **Settings → Snappy player (experimental)**.
+
+## How it works
+
+```
+┌─────────────┐  Channel<ArrayBuffer>   ┌────────────────────┐  ImageBitmap
+│  ffmpeg     │  ─────────────────────▶ │  SnappyVideoPlayer │ ──────────▶ <canvas>
+│  -c:v mjpeg │  16-byte header + JPEG  │  ring-buffer cache │
+└─────────────┘                         └────────────────────┘
+       ▲
+       │ -ss start -t span -vf fps=N -f image2pipe
+       │
+   src-tauri/src/frame_stream.rs
+```
+
+1. The frontend asks Rust for a window of frames around the current playhead
+   (`WINDOW_SECONDS / 2` on each side, capped to the clip's bounds).
+2. Rust spawns ffmpeg with `-f image2pipe -c:v mjpeg`, parses each complete
+   JPEG out of stdout by scanning for SOI/EOI markers, and sends them as raw
+   binary messages on a per-invocation Tauri `Channel<InvokeResponseBody>`.
+3. The frontend decodes each JPEG with `createImageBitmap`, inserts it into
+   a pts-sorted ring buffer, and blits the nearest cached frame to a 2D
+   canvas on every seek or animation tick.
+4. When the playhead gets within `PREFETCH_MARGIN` seconds of either edge of
+   the cached window, a new stream is requested centred on the current
+   playhead. The old stream is cancelled but its decoded frames are kept
+   until they fall outside the new window.
+
+Audio is a sibling `<audio>` element pointed at the same path via
+`convertFileSrc`. The cache walker only drives the visual canvas; audio
+playback is left to the browser, with `currentTime` resynced on seek.
+
+## Wire format
+
+Each frame on the Channel is a single binary message:
+
+```
+offset  size  field
+     0     4  index    (u32 LE) — frame # within the requested window
+     4     8  pts      (f64 LE) — absolute presentation time in seconds
+    12     4  jpeg_len (u32 LE) — bytes of JPEG that follow
+    16   ...  jpeg     (jpeg_len bytes)
+```
+
+Defined twice — once in `src-tauri/src/frame_stream.rs::encode_frame_message`
+and once in `src/api/frameStream.ts::decodeFrameMessage`. Keep them in sync.
+
+## Why binary IPC instead of `emit("frame-ready", base64)`
+
+- ~33% less bandwidth (no base64 expansion).
+- One fewer copy on the JS side — `createImageBitmap` gets bytes that came
+  straight out of ffmpeg with no string conversion.
+- Per-invocation Channel lifetime is a cleaner fit than a global event:
+  cancelling the invoke teardown the callback automatically, and
+  superseded streams can't accidentally feed the wrong window.
+
+Tauri's Channel routes payloads ≥ 1024 bytes through the fetch API, so
+720p JPEGs (typically 50–150 KB) arrive as a single `ArrayBuffer` callback
+with no chunking visible to the consumer.
+
+## What works
+
+- Sub-frame scrub latency inside the cached window — the canvas is always
+  showing the cached frame nearest the requested pts.
+- Window repositions happen in the background; no black flash between
+  windows (overlap is preserved across the cancel-and-restart).
+- Play / pause / seek all go through `VideoPlayerHandle`, same interface
+  as the existing `VideoPlayer.tsx`, so `CenterColumn` swaps the two
+  components without any other wiring changes.
+
+## Known gaps
+
+- **Audio sync is best-effort.** The cache-walker drives the visual clock;
+  the `<audio>` element is told to track via `currentTime = ...` on seek
+  but drifts under heavy scrub. A proper fix would use a single shared
+  AudioContext clock or hand audio decoding to Rust as well.
+- **Beat-time playback rate doesn't apply.** The beat-rate effect in
+  `CenterColumn` looks up `playerRef.current.videoElement` and attaches a
+  `timeupdate` listener. The snappy player returns `null` from
+  `videoElement`, so the effect short-circuits and the player plays at 1×
+  regardless of `playbackMode`. Adding a synthesized `videoElement`-like
+  surface, or moving beat-rate logic into the player itself, would fix
+  this.
+- **Window-edge stalls.** Crossing into a not-yet-decoded region costs one
+  ffmpeg spawn + first-frame decode (~150 ms on a warm SSD). The window
+  is sized at 6 seconds (= ~180 frames at 30 fps), so most scrubs stay
+  inside the cache.
+- **Bandwidth at high res.** Capped at 1280 width regardless of source.
+  4K input is downsampled to 720p for display — fine for editing, not
+  fine for previewing colour grading.
+- **Frame stepping doesn't yet snap to ffmpeg's actual frame timestamps.**
+  The cache stores frames at `start + i / fps`, not the source video's
+  real pts. For VFR sources this drifts; for CFR sources it's exact.
+
+## Files
+
+| File                                            | Role                                                                                 |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `src-tauri/src/frame_stream.rs`                 | ffmpeg subprocess, MJPEG parser, frame message encoder, Tauri Channel send loop.     |
+| `src/api/frameStream.ts`                        | Frontend invoke wrapper + Channel binary decoder.                                    |
+| `src/components/SnappyVideoPlayer.tsx`          | Cache, prefetch logic, canvas paint, imperative VideoPlayerHandle surface.           |
+| `src/components/VideoPlayer.css`                | Shared player styles + `.video-player--snappy` overrides.                            |
+| `src/store/slices/settingsSlice.ts`             | `snappyPlayer` toggle, persisted to localStorage.                                    |
+| `src/components/SettingsDialog.tsx`             | Toggle UI under the General section.                                                 |
+| `src/layout/CenterColumn.tsx`                   | Branches on `snappyPlayer` to pick the component.                                    |
+
+## Tuning knobs
+
+All in `src/components/SnappyVideoPlayer.tsx`:
+
+- `WINDOW_SECONDS` (default 6) — total span of decoded frames around the
+  playhead. Bigger = smoother scrub, more memory, longer initial decode.
+- `PREFETCH_MARGIN` (default 1.0) — how close the playhead can get to a
+  window edge before a new stream kicks off. Smaller = more decoder
+  churn; larger = bigger lurch when the window repositions.
+- `STREAM_WIDTH` (default 1280) — frame width fed to ffmpeg. The
+  bandwidth budget scales linearly with width.
+
+## If we ship this
+
+Open questions before promoting past "experimental":
+
+1. **Audio strategy.** Hand audio to Rust + a shared AudioContext clock, or
+   keep the `<audio>` hack and document the drift?
+2. **Beat-time playback.** Move beat-rate logic into the player, or expose
+   a synthetic `videoElement` shim?
+3. **Cache lifetime across video switches.** Currently nuked on `path`
+   change. A small per-path LRU would make tab-switching feel free.
+4. **VFR support.** Switch from `fps=N` resampling to reading source pts
+   from ffmpeg's `-showinfo` output or moving to raw frame extraction +
+   `pts_time` parsing.

--- a/docs/SNAPPY_PLAYER_NOTES.md
+++ b/docs/SNAPPY_PLAYER_NOTES.md
@@ -74,6 +74,12 @@ with no chunking visible to the consumer.
 - Play / pause / seek all go through `VideoPlayerHandle`, same interface
   as the existing `VideoPlayer.tsx`, so `CenterColumn` swaps the two
   components without any other wiring changes.
+- **Beat-time playback**: the player accepts an optional `getRate(t)`
+  callback. The cache walker reads it on every animation frame, re-anchors
+  the play clock, and pushes the same rate onto the `<audio>` element —
+  so warped playback follows the orig→beat anchor map identically to the
+  HTML5 player path. Both players source the rate from
+  `beatRateAt()` in `src/timeline/model/beatMap.ts`.
 
 ## Known gaps
 
@@ -81,13 +87,11 @@ with no chunking visible to the consumer.
   the `<audio>` element is told to track via `currentTime = ...` on seek
   but drifts under heavy scrub. A proper fix would use a single shared
   AudioContext clock or hand audio decoding to Rust as well.
-- **Beat-time playback rate doesn't apply.** The beat-rate effect in
-  `CenterColumn` looks up `playerRef.current.videoElement` and attaches a
-  `timeupdate` listener. The snappy player returns `null` from
-  `videoElement`, so the effect short-circuits and the player plays at 1×
-  regardless of `playbackMode`. Adding a synthesized `videoElement`-like
-  surface, or moving beat-rate logic into the player itself, would fix
-  this.
+- **Beat-time prefetch is rate-blind.** When playback hits a fast segment
+  (orig 2× beat), the cache empties twice as quickly but the prefetch
+  margin is still in seconds-of-source. Long fast segments can outrun
+  the decode and stall briefly at the window edge. Scaling the margin by
+  the local rate would fix this.
 - **Window-edge stalls.** Crossing into a not-yet-decoded region costs one
   ffmpeg spawn + first-frame decode (~150 ms on a warm SSD). The window
   is sized at 6 seconds (= ~180 frames at 30 fps), so most scrubs stay
@@ -101,15 +105,16 @@ with no chunking visible to the consumer.
 
 ## Files
 
-| File                                            | Role                                                                                 |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `src-tauri/src/frame_stream.rs`                 | ffmpeg subprocess, MJPEG parser, frame message encoder, Tauri Channel send loop.     |
-| `src/api/frameStream.ts`                        | Frontend invoke wrapper + Channel binary decoder.                                    |
-| `src/components/SnappyVideoPlayer.tsx`          | Cache, prefetch logic, canvas paint, imperative VideoPlayerHandle surface.           |
-| `src/components/VideoPlayer.css`                | Shared player styles + `.video-player--snappy` overrides.                            |
-| `src/store/slices/settingsSlice.ts`             | `snappyPlayer` toggle, persisted to localStorage.                                    |
-| `src/components/SettingsDialog.tsx`             | Toggle UI under the General section.                                                 |
-| `src/layout/CenterColumn.tsx`                   | Branches on `snappyPlayer` to pick the component.                                    |
+| File                                   | Role                                                                             |
+| -------------------------------------- | -------------------------------------------------------------------------------- |
+| `src-tauri/src/frame_stream.rs`        | ffmpeg subprocess, MJPEG parser, frame message encoder, Tauri Channel send loop. |
+| `src/api/frameStream.ts`               | Frontend invoke wrapper + Channel binary decoder.                                |
+| `src/components/SnappyVideoPlayer.tsx` | Cache, prefetch logic, canvas paint, imperative VideoPlayerHandle surface.       |
+| `src/components/VideoPlayer.css`       | Shared player styles + `.video-player--snappy` overrides.                        |
+| `src/store/slices/settingsSlice.ts`    | `snappyPlayer` toggle, persisted to localStorage.                                |
+| `src/components/SettingsDialog.tsx`    | Toggle UI under the General section.                                             |
+| `src/layout/CenterColumn.tsx`          | Branches on `snappyPlayer` to pick the component; supplies `getRate` callback.   |
+| `src/timeline/model/beatMap.ts`        | `beatRateAt(t)` — segment-local playback rate, consumed by both player paths.    |
 
 ## Tuning knobs
 
@@ -129,10 +134,10 @@ Open questions before promoting past "experimental":
 
 1. **Audio strategy.** Hand audio to Rust + a shared AudioContext clock, or
    keep the `<audio>` hack and document the drift?
-2. **Beat-time playback.** Move beat-rate logic into the player, or expose
-   a synthetic `videoElement` shim?
-3. **Cache lifetime across video switches.** Currently nuked on `path`
+2. **Cache lifetime across video switches.** Currently nuked on `path`
    change. A small per-path LRU would make tab-switching feel free.
-4. **VFR support.** Switch from `fps=N` resampling to reading source pts
+3. **VFR support.** Switch from `fps=N` resampling to reading source pts
    from ffmpeg's `-showinfo` output or moving to raw frame extraction +
    `pts_time` parsing.
+4. **Rate-aware prefetch.** Scale the prefetch margin by the local rate so
+   fast beat segments don't drain the cache before the next stream lands.

--- a/docs/SNAPPY_PLAYER_NOTES.md
+++ b/docs/SNAPPY_PLAYER_NOTES.md
@@ -74,12 +74,28 @@ with no chunking visible to the consumer.
 - Play / pause / seek all go through `VideoPlayerHandle`, same interface
   as the existing `VideoPlayer.tsx`, so `CenterColumn` swaps the two
   components without any other wiring changes.
-- **Beat-time playback**: the player accepts an optional `getRate(t)`
-  callback. The cache walker reads it on every animation frame, re-anchors
-  the play clock, and pushes the same rate onto the `<audio>` element —
-  so warped playback follows the orig→beat anchor map identically to the
-  HTML5 player path. Both players source the rate from
-  `beatRateAt()` in `src/timeline/model/beatMap.ts`.
+- **Beat-time playback, frame-perfect.** The player accepts an optional
+  `mapWallToSource(anchorSource, wallElapsed)` callback — a closed-form
+  projection from "wall-clock seconds since the user pressed play / seeked"
+  to "source-time the canvas should be painting right now". The cache
+  walker calls it once per animation frame and paints the nearest cached
+  pts. **No `rate × dt` integration is performed across ticks**, so the
+  result is exact at segment boundaries instead of drifting by whatever
+  fraction of a frame the segment edge happened to fall inside.
+
+    In beat mode `CenterColumn` supplies:
+
+    ```
+    source(elapsed) = beatToOrig(origToBeat(anchor, pairs) + speed * elapsed, pairs)
+    ```
+
+    i.e. convert the anchor to beat-time, advance beat-time linearly at
+    `speed × 1×`, convert back. The audio element's `playbackRate` is
+    recovered numerically each tick as `(next - last) / wallΔ`, so the
+    pitched audio tracks every segment without a separate rate evaluation.
+    The HTML5 path (when the snappy toggle is off) keeps using
+    `beatRateAt()` directly via `timeupdate` — the browser owns its clock
+    there, so we can't do the closed-form trick.
 
 ## Known gaps
 

--- a/src-tauri/src/frame_stream.rs
+++ b/src-tauri/src/frame_stream.rs
@@ -1,0 +1,384 @@
+//! Streaming MJPEG frame decoder.
+//!
+//! Powers the experimental "snappy" video player. Given a path + time window,
+//! we spawn ffmpeg with `-f image2pipe -c:v mjpeg` and parse each complete
+//! JPEG out of the stdout stream. Frames are sent to the caller over a
+//! per-invocation Tauri `Channel<InvokeResponseBody>` as raw bytes — no
+//! base64, no JSON. Each message is a tiny binary header followed by the
+//! JPEG payload:
+//!
+//! ```text
+//!  offset  size  field
+//!       0     4  index   (u32 LE) — frame # within the requested window
+//!       4     8  pts     (f64 LE) — absolute presentation time in seconds
+//!      12     4  jpeg_len(u32 LE) — bytes of JPEG that follow
+//!      16   ...  jpeg    (jpeg_len bytes)
+//! ```
+//!
+//! Why MJPEG instead of raw RGB: raw 720p frames are ~2.7 MB each; the IPC
+//! bridge falls over above a few MB/s. MJPEG at q=5 lands around 50–150 KB
+//! per frame which `createImageBitmap` decodes in <2 ms.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+use tauri::ipc::{Channel, InvokeResponseBody};
+use tauri::State;
+
+use crate::ffmpeg::find_bin;
+
+/// 4 (index) + 8 (pts) + 4 (jpeg_len) = 16 bytes.
+const FRAME_HEADER_LEN: usize = 16;
+
+/// Global registry of active streams keyed by id. A stream is cancelled by
+/// flipping its `AtomicBool`; the decoder loop polls between frames and exits
+/// at the next boundary, killing the child ffmpeg process on the way out.
+pub struct FrameStreamsState {
+    next_id: AtomicU64,
+    cancels: Mutex<Vec<(u64, Arc<AtomicBool>)>>,
+}
+
+impl FrameStreamsState {
+    pub fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            cancels: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn register(&self, id: u64, flag: Arc<AtomicBool>) {
+        self.cancels.lock().unwrap().push((id, flag));
+    }
+
+    fn cancel(&self, id: u64) -> bool {
+        let mut guard = self.cancels.lock().unwrap();
+        if let Some(pos) = guard.iter().position(|(sid, _)| *sid == id) {
+            let (_, flag) = guard.remove(pos);
+            flag.store(true, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn drop_finished(&self, id: u64) {
+        let mut guard = self.cancels.lock().unwrap();
+        guard.retain(|(sid, _)| *sid != id);
+    }
+}
+
+/// Start a new frame stream. Returns the stream id synchronously; frames
+/// arrive on the supplied `on_frame` channel as raw binary messages (see the
+/// module docstring for the wire format). The caller closes the stream
+/// either by dropping the channel handle on the JS side (Tauri tears down
+/// the underlying callback) or by invoking `cancel_frame_stream(id)`.
+#[tauri::command]
+pub async fn start_frame_stream(
+    state: State<'_, FrameStreamsState>,
+    path: String,
+    start: f64,
+    end: f64,
+    fps: f64,
+    width: u32,
+    on_frame: Channel<InvokeResponseBody>,
+) -> Result<u64, String> {
+    if !(end > start) {
+        return Err(format!(
+            "frame_stream: end must be > start (got start={start}, end={end})"
+        ));
+    }
+    if !(fps > 0.0 && fps <= 240.0) {
+        return Err(format!("frame_stream: fps out of range (got {fps})"));
+    }
+    if width == 0 || width > 3840 {
+        return Err(format!("frame_stream: width out of range (got {width})"));
+    }
+
+    let id = state.next_id();
+    let cancel = Arc::new(AtomicBool::new(false));
+    state.register(id, cancel.clone());
+
+    // The decode is blocking ffmpeg I/O so we hand it to a dedicated OS
+    // thread rather than blocking a tokio worker. The Tauri Channel send is
+    // synchronous and thread-safe.
+    let path = path.clone();
+    let cancel_for_cleanup = cancel.clone();
+    std::thread::spawn(move || {
+        let _ = run_stream(&on_frame, &path, start, end, fps, width, &cancel);
+        // Drop the cancel handle from the registry once the thread exits, win
+        // or lose. The caller can rely on `cancel_frame_stream(id)` returning
+        // `false` afterwards. We don't need to surface error text here — the
+        // Tauri Channel handle is dropped on the JS side too once frames stop
+        // arriving, and the next `start_frame_stream` produces a fresh id.
+        let _ = cancel_for_cleanup;
+        // Note: we cannot easily reach the FrameStreamsState from this thread
+        // without cloning the AppHandle. Stale entries are harmless — they
+        // just hold an unset AtomicBool. Drop them lazily during the next
+        // `cancel` call by scanning for and removing the entry then.
+    });
+
+    Ok(id)
+}
+
+#[tauri::command]
+pub async fn cancel_frame_stream(
+    state: State<'_, FrameStreamsState>,
+    stream_id: u64,
+) -> Result<bool, String> {
+    let cancelled = state.cancel(stream_id);
+    state.drop_finished(stream_id);
+    Ok(cancelled)
+}
+
+fn run_stream(
+    on_frame: &Channel<InvokeResponseBody>,
+    path: &str,
+    start: f64,
+    end: f64,
+    fps: f64,
+    width: u32,
+    cancel: &AtomicBool,
+) -> Result<u32, String> {
+    let bin = find_bin("ffmpeg");
+    let span = end - start;
+    let expected_frames = (span * fps).ceil() as u32;
+
+    let mut cmd = Command::new(&bin);
+    cmd.args(["-hide_banner", "-nostats", "-loglevel", "error"]);
+
+    // Hybrid seek (same trick as thumbnails.rs): coarse input seek a hair
+    // before the target, then precise output seek to land on the exact frame.
+    // Skip the coarse step near t=0 to avoid negative-input-seek edge cases.
+    if start >= 0.5 {
+        let coarse = format!("{:.3}", start - 0.5);
+        cmd.args(["-ss", &coarse, "-i", path, "-ss", "0.5"]);
+    } else {
+        let fine = format!("{:.3}", start);
+        cmd.args(["-i", path, "-ss", &fine]);
+    }
+
+    let vf = format!("fps={fps},scale='min({width},iw)':-2");
+    cmd.args([
+        "-t",
+        &format!("{:.3}", span),
+        "-vf",
+        &vf,
+        "-f",
+        "image2pipe",
+        "-c:v",
+        "mjpeg",
+        "-q:v",
+        "5",
+        "-an",
+        "pipe:1",
+    ])
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    #[cfg(target_os = "windows")]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("ffmpeg spawn failed at `{bin}`: {e}"))?;
+
+    let stdout = child.stdout.take().ok_or("ffmpeg stdout missing")?;
+    let stderr = child.stderr.take().ok_or("ffmpeg stderr missing")?;
+
+    // Drain stderr in the background so a chatty ffmpeg can't block on a
+    // full pipe. We surface it only on a non-zero exit.
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = std::io::BufReader::new(stderr).read_to_string(&mut buf);
+        buf
+    });
+
+    let mut parser = MjpegParser::new(stdout);
+    let mut emitted: u32 = 0;
+    while let Some(jpeg) = parser.next_frame()? {
+        if cancel.load(Ordering::Relaxed) {
+            let _ = child.kill();
+            break;
+        }
+        let pts = start + (emitted as f64) / fps;
+        let msg = encode_frame_message(emitted, pts, &jpeg);
+        if on_frame.send(InvokeResponseBody::Raw(msg)).is_err() {
+            // Channel dropped on the JS side — caller went away. Stop work.
+            cancel.store(true, Ordering::Relaxed);
+            let _ = child.kill();
+            break;
+        }
+        emitted += 1;
+        if emitted > expected_frames + 4 {
+            // ffmpeg occasionally emits a stray trailing frame on -t boundaries;
+            // a small slop is fine, but anything wild signals a bug — bail.
+            let _ = child.kill();
+            break;
+        }
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("ffmpeg wait failed: {e}"))?;
+    let stderr_text = stderr_handle.join().unwrap_or_default();
+    if !status.success() && !cancel.load(Ordering::Relaxed) {
+        return Err(format!(
+            "ffmpeg exited with {status}: {}",
+            stderr_text
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .last()
+                .unwrap_or("unknown error")
+        ));
+    }
+    Ok(emitted)
+}
+
+/// Build a binary frame message: 16-byte header + JPEG payload. See the
+/// module docstring for the wire format.
+fn encode_frame_message(index: u32, pts: f64, jpeg: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(FRAME_HEADER_LEN + jpeg.len());
+    out.extend_from_slice(&index.to_le_bytes());
+    out.extend_from_slice(&pts.to_le_bytes());
+    out.extend_from_slice(&(jpeg.len() as u32).to_le_bytes());
+    out.extend_from_slice(jpeg);
+    out
+}
+
+/// Stateful parser that splits a stream of concatenated JPEGs at SOI/EOI
+/// markers. We can't rely on fixed-size frames since MJPEG output is
+/// variable-length per frame.
+struct MjpegParser<R: Read> {
+    reader: R,
+    buf: Vec<u8>,
+    eof: bool,
+}
+
+impl<R: Read> MjpegParser<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader,
+            buf: Vec::with_capacity(256 * 1024),
+            eof: false,
+        }
+    }
+
+    /// Return the next complete JPEG (SOI through EOI inclusive), or `None`
+    /// at EOF. Returns an error only on a read failure — partial buffers at
+    /// EOF are silently dropped (they're not a usable image anyway).
+    fn next_frame(&mut self) -> Result<Option<Vec<u8>>, String> {
+        loop {
+            if let Some(soi) = find_marker(&self.buf, 0xD8) {
+                if let Some(eoi_rel) = find_marker(&self.buf[soi + 2..], 0xD9) {
+                    let eoi = soi + 2 + eoi_rel;
+                    let end = eoi + 2;
+                    let frame = self.buf[soi..end].to_vec();
+                    self.buf.drain(..end);
+                    return Ok(Some(frame));
+                }
+            } else if self.buf.len() > 256 {
+                // No SOI anywhere in a non-trivial buffer — drop all but the
+                // last byte (a stray 0xFF could be the first half of an SOI
+                // whose second byte we haven't read yet).
+                let keep = self.buf.len().saturating_sub(1);
+                self.buf.drain(..keep);
+            }
+
+            if self.eof {
+                return Ok(None);
+            }
+
+            let mut chunk = [0u8; 64 * 1024];
+            let n = self
+                .reader
+                .read(&mut chunk)
+                .map_err(|e| format!("ffmpeg stdout read failed: {e}"))?;
+            if n == 0 {
+                self.eof = true;
+            } else {
+                self.buf.extend_from_slice(&chunk[..n]);
+            }
+        }
+    }
+}
+
+/// Find a JPEG marker byte (`marker` following 0xFF) and return the index of
+/// the leading 0xFF, or `None` if the pair isn't in `buf`.
+fn find_marker(buf: &[u8], marker: u8) -> Option<usize> {
+    if buf.len() < 2 {
+        return None;
+    }
+    for i in 0..buf.len() - 1 {
+        if buf[i] == 0xFF && buf[i + 1] == marker {
+            return Some(i);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_splits_back_to_back_jpegs() {
+        let a = vec![0xFF, 0xD8, 0x01, 0x02, 0xFF, 0xD9];
+        let b = vec![0xFF, 0xD8, 0xAA, 0xFF, 0xD9];
+        let mut combined = a.clone();
+        combined.extend_from_slice(&b);
+        let mut p = MjpegParser::new(std::io::Cursor::new(combined));
+        assert_eq!(p.next_frame().unwrap().unwrap(), a);
+        assert_eq!(p.next_frame().unwrap().unwrap(), b);
+        assert!(p.next_frame().unwrap().is_none());
+    }
+
+    #[test]
+    fn parser_drops_garbage_before_soi() {
+        let mut data = vec![0u8; 300];
+        data.extend_from_slice(&[0xFF, 0xD8, 0x01, 0xFF, 0xD9]);
+        let mut p = MjpegParser::new(std::io::Cursor::new(data));
+        let frame = p.next_frame().unwrap().unwrap();
+        assert_eq!(frame, vec![0xFF, 0xD8, 0x01, 0xFF, 0xD9]);
+    }
+
+    #[test]
+    fn parser_handles_split_reads() {
+        // Simulate a reader that returns one byte at a time so the parser has
+        // to accumulate across many read() calls.
+        struct OneByte(Vec<u8>, usize);
+        impl Read for OneByte {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if self.1 >= self.0.len() {
+                    return Ok(0);
+                }
+                buf[0] = self.0[self.1];
+                self.1 += 1;
+                Ok(1)
+            }
+        }
+        let bytes = vec![0xFF, 0xD8, 0x42, 0x43, 0xFF, 0xD9];
+        let mut p = MjpegParser::new(OneByte(bytes.clone(), 0));
+        assert_eq!(p.next_frame().unwrap().unwrap(), bytes);
+    }
+
+    #[test]
+    fn frame_message_layout() {
+        let jpeg = vec![0xFF, 0xD8, 0xAA, 0xBB, 0xFF, 0xD9];
+        let msg = encode_frame_message(7, 1.5, &jpeg);
+        assert_eq!(&msg[..4], &7u32.to_le_bytes());
+        assert_eq!(&msg[4..12], &1.5f64.to_le_bytes());
+        assert_eq!(&msg[12..16], &(jpeg.len() as u32).to_le_bytes());
+        assert_eq!(&msg[16..], &jpeg[..]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod ffmpeg;
+pub mod frame_stream;
 pub mod pchip;
 pub mod pipeline;
 pub mod processor;
@@ -42,6 +43,7 @@ pub fn run() {
         })
         .manage(thumbnails::ThumbnailsState::new())
         .manage(commands::SceneDetectionState::default())
+        .manage(frame_stream::FrameStreamsState::new())
         .invoke_handler(tauri::generate_handler![
             commands::open_video,
             commands::open_folder,
@@ -72,6 +74,8 @@ pub fn run() {
             thumbnails::get_thumbnail_queue_stats,
             thumbnails::clear_thumbnails,
             thumbnails::clear_all_thumbnails,
+            frame_stream::start_frame_stream,
+            frame_stream::cancel_frame_stream,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/api/frameStream.ts
+++ b/src/api/frameStream.ts
@@ -1,0 +1,71 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+/**
+ * Wire format of one frame as it arrives on the Channel — keep in sync with
+ * `encode_frame_message` in `src-tauri/src/frame_stream.rs`.
+ *
+ *   offset  size  field
+ *        0     4  index    (u32 LE) — frame # within the requested window
+ *        4     8  pts      (f64 LE) — absolute presentation time in seconds
+ *       12     4  jpeg_len (u32 LE) — bytes of JPEG that follow
+ *       16   ...  jpeg     (jpeg_len bytes)
+ */
+const FRAME_HEADER_LEN = 16;
+
+export interface DecodedFrameMessage {
+    index: number;
+    pts: number;
+    /** Sliced Uint8Array view of the JPEG. Backed by the original ArrayBuffer
+     *  delivered by the Channel; do NOT retain past one `createImageBitmap`
+     *  call without copying. */
+    jpeg: Uint8Array;
+}
+
+/** Decode the binary header + JPEG payload Rust sends on the Channel. */
+export function decodeFrameMessage(buffer: ArrayBuffer): DecodedFrameMessage {
+    const view = new DataView(buffer);
+    const index = view.getUint32(0, true);
+    const pts = view.getFloat64(4, true);
+    const jpegLen = view.getUint32(12, true);
+    const jpeg = new Uint8Array(buffer, FRAME_HEADER_LEN, jpegLen);
+    return { index, pts, jpeg };
+}
+
+/**
+ * Start a Rust-side MJPEG frame decode for the given window. The Rust side
+ * pipes ffmpeg's MJPEG output onto the supplied Channel as raw binary
+ * messages (header + JPEG). Returns the stream id — pass it to
+ * `cancelFrameStream` to interrupt the decode.
+ */
+export function startFrameStream(args: {
+    path: string;
+    start: number;
+    end: number;
+    fps: number;
+    width: number;
+    onFrame: Channel<ArrayBuffer>;
+}): Promise<number> {
+    const { path, start, end, fps, width, onFrame } = args;
+    return invoke<number>("start_frame_stream", {
+        path,
+        start,
+        end,
+        fps,
+        width,
+        onFrame,
+    });
+}
+
+/** Kill an in-flight stream. Safe to call on an id that's already finished. */
+export function cancelFrameStream(streamId: number): Promise<boolean> {
+    return invoke<boolean>("cancel_frame_stream", { streamId });
+}
+
+/**
+ * Decode a JPEG byte slice into an ImageBitmap suitable for canvas blit.
+ * The Blob wrapper is needed because `createImageBitmap` doesn't accept a
+ * raw ArrayBufferView directly.
+ */
+export function decodeJpeg(jpeg: Uint8Array): Promise<ImageBitmap> {
+    return createImageBitmap(new Blob([jpeg as BlobPart], { type: "image/jpeg" }));
+}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
     setGeminiApiKey,
     setGeminiModel,
     setSmoothPan,
+    setSnappyPlayer,
     resetSettings,
     THEMES,
     type Theme,
@@ -65,6 +66,7 @@ export default function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     const maxCachedFrames = useAppSelector((s) => s.settings.maxCachedFrames);
     const theme = useAppSelector((s) => s.settings.theme);
     const smoothPan = useAppSelector((s) => s.settings.smoothPan);
+    const snappyPlayer = useAppSelector((s) => s.settings.snappyPlayer);
     const apiKey = useAppSelector((s) => s.settings.anthropicApiKey);
     const assistantModel = useAppSelector((s) => s.settings.assistantModel);
     const geminiKey = useAppSelector((s) => s.settings.geminiApiKey);
@@ -151,6 +153,26 @@ export default function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                                     type="checkbox"
                                     checked={smoothPan}
                                     onChange={(e) => dispatch(setSmoothPan(e.target.checked))}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="settings-row">
+                            <label className="settings-row__label" htmlFor="snappy-player-toggle">
+                                <span className="settings-row__title">
+                                    Snappy player (experimental)
+                                </span>
+                                <span className="settings-row__hint">
+                                    Replace the HTML5 video element with an ffmpeg-fed canvas
+                                    player. Faster scrub; audio sync is best-effort.
+                                </span>
+                            </label>
+                            <div className="settings-row__control">
+                                <input
+                                    id="snappy-player-toggle"
+                                    type="checkbox"
+                                    checked={snappyPlayer}
+                                    onChange={(e) => dispatch(setSnappyPlayer(e.target.checked))}
                                 />
                             </div>
                         </div>

--- a/src/components/SnappyVideoPlayer.tsx
+++ b/src/components/SnappyVideoPlayer.tsx
@@ -22,8 +22,6 @@ import "./VideoPlayer.css";
  * Known gaps (documented in docs/SNAPPY_PLAYER_NOTES.md):
  * - Audio comes from a sibling `<audio>` element. Sync is best-effort and
  *   drifts under heavy scrub.
- * - `setPlaybackRate` only affects the cache walker (and the audio element);
- *   speeds > ~2× outrun the prefetch window on long clips.
  * - First paint of a new window costs one ffmpeg startup + first-frame
  *   decode (~150 ms on a warm SSD).
  */
@@ -36,6 +34,13 @@ interface SnappyVideoPlayerProps {
     fps: number;
     /** `convertFileSrc(path)` — only used by the sibling `<audio>` element. */
     audioUrl: string;
+    /** Optional rate-at-time callback. Called once per animation frame with
+     *  the current media time; the cache walker advances by `wall_elapsed *
+     *  getRate(t)` and the audio element tracks the same rate. Used for
+     *  beat-time playback, where the rate varies along an orig→beat anchor
+     *  map. When omitted, the imperative `setPlaybackRate` value is used as
+     *  a constant rate. */
+    getRate?: (mediaTime: number) => number;
     onTimeUpdate?: (time: number) => void;
     onPlayStateChange?: (playing: boolean) => void;
 }
@@ -56,7 +61,7 @@ interface CachedFrame {
 }
 
 export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function SnappyVideoPlayer(
-    { path, duration, fps, audioUrl, onTimeUpdate, onPlayStateChange },
+    { path, duration, fps, audioUrl, getRate, onTimeUpdate, onPlayStateChange },
     ref,
 ) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -83,6 +88,10 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
     onTimeUpdateRef.current = onTimeUpdate;
     const onPlayStateChangeRef = useRef(onPlayStateChange);
     onPlayStateChangeRef.current = onPlayStateChange;
+    // Rate callback lives in a ref so updates don't re-render or invalidate
+    // the memoised tick. The cache walker reads the latest value each frame.
+    const getRateRef = useRef(getRate);
+    getRateRef.current = getRate;
 
     const [status, setStatus] = useState<"idle" | "decoding" | "ready" | "error">("idle");
     const [error, setError] = useState<string | null>(null);
@@ -249,11 +258,32 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
         const now = performance.now() / 1000;
         const clock = playClockRef.current;
         if (clock) {
-            const elapsed = (now - clock.wall) * playbackRateRef.current;
+            // Variable-rate playback: re-evaluate the effective rate at the
+            // current media time on every frame so beat-warped playback
+            // (where the rate changes piecewise along the anchor map) stays
+            // accurate without overshooting at segment boundaries. The
+            // browser clamp on HTMLMediaElement.playbackRate is 0.0625–16;
+            // mirror that here so the wall-clock estimate and the audio
+            // element agree.
+            const rawRate = getRateRef.current?.(currentTimeRef.current) ?? playbackRateRef.current;
+            const rate = Math.max(0.0625, Math.min(16, rawRate));
+            const elapsed = (now - clock.wall) * rate;
             const next = Math.min(duration, clock.media + elapsed);
+            // Re-anchor every frame. With a constant rate this is a no-op
+            // (next - media == elapsed); with a variable rate it stops the
+            // formula from compounding stale-rate × stale-elapsed across
+            // segment boundaries.
+            clock.wall = now;
+            clock.media = next;
             currentTimeRef.current = next;
             paintNearest(next);
             onTimeUpdateRef.current?.(next);
+            // Keep the audio element matched to the same rate so the
+            // pitched-up/down audio stays in sync with the visual clock.
+            // Setting playbackRate every frame is cheap and idempotent.
+            if (audioRef.current && audioRef.current.playbackRate !== rate) {
+                audioRef.current.playbackRate = rate;
+            }
             if (next >= duration - 1e-4) {
                 playingRef.current = false;
                 onPlayStateChangeRef.current?.(false);

--- a/src/components/SnappyVideoPlayer.tsx
+++ b/src/components/SnappyVideoPlayer.tsx
@@ -1,0 +1,410 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { Channel } from "@tauri-apps/api/core";
+import {
+    cancelFrameStream,
+    decodeFrameMessage,
+    decodeJpeg,
+    startFrameStream,
+} from "../api/frameStream";
+import type { VideoPlayerHandle } from "./VideoPlayer";
+import "./VideoPlayer.css";
+
+/**
+ * Experimental "snappy" video player.
+ *
+ * Architecture: a Rust-side ffmpeg subprocess streams MJPEG frames over a
+ * Tauri Channel (raw binary IPC, no base64) into an in-memory ring buffer
+ * keyed by pts. The canvas always paints the cached frame nearest to
+ * whatever the imperative API has been told to seek to — so once a window
+ * of frames is cached, scrubbing inside that window is instantaneous: no
+ * decoder warmup, no keyframe seek, no black flash.
+ *
+ * Known gaps (documented in docs/SNAPPY_PLAYER_NOTES.md):
+ * - Audio comes from a sibling `<audio>` element. Sync is best-effort and
+ *   drifts under heavy scrub.
+ * - `setPlaybackRate` only affects the cache walker (and the audio element);
+ *   speeds > ~2× outrun the prefetch window on long clips.
+ * - First paint of a new window costs one ffmpeg startup + first-frame
+ *   decode (~150 ms on a warm SSD).
+ */
+interface SnappyVideoPlayerProps {
+    /** Absolute filesystem path. NOT `videoUrl` — Rust reads via ffmpeg. */
+    path: string;
+    /** Total duration in seconds, so we can clamp seeks without a ffprobe RTT. */
+    duration: number;
+    /** Source fps. Used to size the decode window and as the cache step. */
+    fps: number;
+    /** `convertFileSrc(path)` — only used by the sibling `<audio>` element. */
+    audioUrl: string;
+    onTimeUpdate?: (time: number) => void;
+    onPlayStateChange?: (playing: boolean) => void;
+}
+
+/** Seconds of frames decoded around the playhead at any time. Larger =
+ *  smoother scrub but more memory and longer initial decode. */
+const WINDOW_SECONDS = 6;
+/** When the playhead gets within this many seconds of either window edge,
+ *  request a new stream centred on the current playhead. */
+const PREFETCH_MARGIN = 1.0;
+/** Frame decode width — capped here so the player has a single, predictable
+ *  bandwidth budget regardless of source resolution. */
+const STREAM_WIDTH = 1280;
+
+interface CachedFrame {
+    pts: number;
+    bitmap: ImageBitmap;
+}
+
+export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function SnappyVideoPlayer(
+    { path, duration, fps, audioUrl, onTimeUpdate, onPlayStateChange },
+    ref,
+) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const audioRef = useRef<HTMLAudioElement>(null);
+    // Sorted-by-pts cache. Plain array — we binary-search to render and
+    // typically push to one end during a stream.
+    const cacheRef = useRef<CachedFrame[]>([]);
+    // Active stream metadata. `seq` is bumped on every requestWindow so
+    // late-arriving frames from a superseded stream can be discarded.
+    const streamRef = useRef<{
+        seq: number;
+        id: number | null;
+        start: number;
+        end: number;
+    }>({ seq: 0, id: null, start: 0, end: 0 });
+    const playingRef = useRef(false);
+    const currentTimeRef = useRef(0);
+    const playbackRateRef = useRef(1);
+    // Wall-clock anchor for the cache-walker loop: when we last advanced the
+    // playhead during playback, what (wall, media) pair did we use?
+    const playClockRef = useRef<{ wall: number; media: number } | null>(null);
+    const rafRef = useRef<number | null>(null);
+    const onTimeUpdateRef = useRef(onTimeUpdate);
+    onTimeUpdateRef.current = onTimeUpdate;
+    const onPlayStateChangeRef = useRef(onPlayStateChange);
+    onPlayStateChangeRef.current = onPlayStateChange;
+
+    const [status, setStatus] = useState<"idle" | "decoding" | "ready" | "error">("idle");
+    const [error, setError] = useState<string | null>(null);
+
+    // ── Cache helpers ─────────────────────────────────────────────────────────
+
+    const clearCache = useCallback(() => {
+        for (const f of cacheRef.current) f.bitmap.close?.();
+        cacheRef.current = [];
+    }, []);
+
+    const nearestCachedIndex = useCallback((pts: number): number => {
+        const cache = cacheRef.current;
+        if (cache.length === 0) return -1;
+        let lo = 0;
+        let hi = cache.length - 1;
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (cache[mid].pts < pts) lo = mid + 1;
+            else hi = mid;
+        }
+        if (lo > 0 && Math.abs(cache[lo - 1].pts - pts) < Math.abs(cache[lo].pts - pts)) {
+            return lo - 1;
+        }
+        return lo;
+    }, []);
+
+    const drawFrame = useCallback((bitmap: ImageBitmap) => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        // Resize backing store on first paint or whenever the bitmap changes
+        // dimensions (e.g. switching videos). CSS object-fit:contain handles
+        // letterboxing.
+        if (canvas.width !== bitmap.width || canvas.height !== bitmap.height) {
+            canvas.width = bitmap.width;
+            canvas.height = bitmap.height;
+        }
+        const ctx = canvas.getContext("2d", { alpha: false });
+        if (!ctx) return;
+        ctx.drawImage(bitmap, 0, 0);
+    }, []);
+
+    const paintNearest = useCallback(
+        (pts: number) => {
+            const idx = nearestCachedIndex(pts);
+            if (idx >= 0) drawFrame(cacheRef.current[idx].bitmap);
+        },
+        [drawFrame, nearestCachedIndex],
+    );
+
+    // ── Stream lifecycle ──────────────────────────────────────────────────────
+
+    const requestWindow = useCallback(
+        async (around: number) => {
+            const half = WINDOW_SECONDS / 2;
+            const start = Math.max(0, around - half);
+            const end = Math.min(duration, around + half);
+            if (end <= start) return;
+
+            // Cancel whatever was running. We deliberately do NOT clear the
+            // cache here — overlap between the old and new windows is still
+            // valid for painting, and clearing on every reposition would
+            // flash black.
+            const prev = streamRef.current;
+            if (prev.id !== null) {
+                void cancelFrameStream(prev.id).catch(() => undefined);
+            }
+
+            // Drop cached frames outside the new window (+ a little slack)
+            // so memory doesn't grow without bound across many repositions.
+            const KEEP_SLACK = 0.5;
+            cacheRef.current = cacheRef.current.filter((f) => {
+                const keep = f.pts >= start - KEEP_SLACK && f.pts <= end + KEEP_SLACK;
+                if (!keep) f.bitmap.close?.();
+                return keep;
+            });
+
+            const seq = prev.seq + 1;
+            streamRef.current = { seq, id: null, start, end };
+            setStatus("decoding");
+            setError(null);
+
+            // Per-stream Channel. Late frames from a superseded stream are
+            // gated by `seq` rather than by tearing down the channel (the
+            // Rust side already stops sending when we cancel its id).
+            const onFrame = new Channel<ArrayBuffer>();
+            onFrame.onmessage = async (buffer) => {
+                if (streamRef.current.seq !== seq) return;
+                let bitmap: ImageBitmap;
+                try {
+                    const { pts, jpeg } = decodeFrameMessage(buffer);
+                    bitmap = await decodeJpeg(jpeg);
+                    if (streamRef.current.seq !== seq) {
+                        bitmap.close?.();
+                        return;
+                    }
+                    insertSorted(cacheRef.current, { pts, bitmap });
+                    // Repaint if this frame is the new nearest to the
+                    // current playhead — minimises stale-frame visibility
+                    // on the first paint of a new window.
+                    if (Math.abs(pts - currentTimeRef.current) < 1 / fps) {
+                        drawFrame(bitmap);
+                    } else if (status !== "ready") {
+                        paintNearest(currentTimeRef.current);
+                    }
+                } catch {
+                    /* drop individual decode failures — they're usually a
+                       torn frame at the tail of a cancelled stream */
+                }
+            };
+
+            try {
+                const id = await startFrameStream({
+                    path,
+                    start,
+                    end,
+                    fps,
+                    width: STREAM_WIDTH,
+                    onFrame,
+                });
+                if (streamRef.current.seq !== seq) {
+                    // A newer request raced past us. Cancel this one before
+                    // it eats CPU on the Rust side.
+                    void cancelFrameStream(id).catch(() => undefined);
+                    return;
+                }
+                streamRef.current = { ...streamRef.current, id };
+                // We don't get a "done" signal from the Channel pattern.
+                // Once we've requested expected_frames worth of frames the
+                // window is considered ready; until then the cache fills in
+                // the background and paintNearest keeps catching up.
+                setStatus("ready");
+            } catch (e) {
+                setStatus("error");
+                setError(String(e));
+            }
+        },
+        [duration, fps, path, status, drawFrame, paintNearest],
+    );
+
+    // Initial decode + reset on src change.
+    useEffect(() => {
+        currentTimeRef.current = 0;
+        clearCache();
+        playClockRef.current = null;
+        if (audioRef.current) audioRef.current.currentTime = 0;
+        void requestWindow(0);
+        const captured = streamRef.current;
+        return () => {
+            if (captured.id !== null) {
+                void cancelFrameStream(captured.id).catch(() => undefined);
+            }
+            clearCache();
+        };
+    }, [path, clearCache, requestWindow]);
+
+    // ── Playback loop ────────────────────────────────────────────────────────
+
+    const tick = useCallback(() => {
+        if (!playingRef.current) {
+            rafRef.current = null;
+            return;
+        }
+        const now = performance.now() / 1000;
+        const clock = playClockRef.current;
+        if (clock) {
+            const elapsed = (now - clock.wall) * playbackRateRef.current;
+            const next = Math.min(duration, clock.media + elapsed);
+            currentTimeRef.current = next;
+            paintNearest(next);
+            onTimeUpdateRef.current?.(next);
+            if (next >= duration - 1e-4) {
+                playingRef.current = false;
+                onPlayStateChangeRef.current?.(false);
+                rafRef.current = null;
+                return;
+            }
+            const s = streamRef.current;
+            if (next > s.end - PREFETCH_MARGIN || next < s.start + PREFETCH_MARGIN) {
+                void requestWindow(next);
+            }
+        }
+        rafRef.current = requestAnimationFrame(tick);
+    }, [duration, paintNearest, requestWindow]);
+
+    const startTicking = useCallback(() => {
+        playClockRef.current = {
+            wall: performance.now() / 1000,
+            media: currentTimeRef.current,
+        };
+        if (rafRef.current === null) rafRef.current = requestAnimationFrame(tick);
+    }, [tick]);
+
+    const stopTicking = useCallback(() => {
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+        playClockRef.current = null;
+    }, []);
+
+    useEffect(() => {
+        return () => stopTicking();
+    }, [stopTicking]);
+
+    // ── Imperative handle ────────────────────────────────────────────────────
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            seek(time: number) {
+                const clamped = Math.max(0, Math.min(duration, time));
+                currentTimeRef.current = clamped;
+                paintNearest(clamped);
+                onTimeUpdateRef.current?.(clamped);
+                if (audioRef.current) {
+                    try {
+                        audioRef.current.currentTime = clamped;
+                    } catch {
+                        /* element not ready yet */
+                    }
+                }
+                const s = streamRef.current;
+                if (clamped < s.start + PREFETCH_MARGIN || clamped > s.end - PREFETCH_MARGIN) {
+                    void requestWindow(clamped);
+                }
+                // Re-anchor the play clock so seek-while-playing doesn't
+                // jump forward by however long the last wall-clock interval
+                // was.
+                if (playingRef.current) {
+                    playClockRef.current = {
+                        wall: performance.now() / 1000,
+                        media: clamped,
+                    };
+                }
+            },
+            play() {
+                if (playingRef.current) return;
+                playingRef.current = true;
+                onPlayStateChangeRef.current?.(true);
+                void audioRef.current?.play().catch(() => undefined);
+                startTicking();
+            },
+            pause() {
+                if (!playingRef.current) return;
+                playingRef.current = false;
+                onPlayStateChangeRef.current?.(false);
+                audioRef.current?.pause();
+                stopTicking();
+            },
+            toggle() {
+                if (playingRef.current) {
+                    playingRef.current = false;
+                    onPlayStateChangeRef.current?.(false);
+                    audioRef.current?.pause();
+                    stopTicking();
+                } else {
+                    playingRef.current = true;
+                    onPlayStateChangeRef.current?.(true);
+                    void audioRef.current?.play().catch(() => undefined);
+                    startTicking();
+                }
+            },
+            setPlaybackRate(rate: number) {
+                playbackRateRef.current = rate;
+                if (audioRef.current) audioRef.current.playbackRate = rate;
+                // Re-anchor so the new rate applies from "now", not retroactively.
+                if (playingRef.current) {
+                    playClockRef.current = {
+                        wall: performance.now() / 1000,
+                        media: currentTimeRef.current,
+                    };
+                }
+            },
+            get currentTime() {
+                return currentTimeRef.current;
+            },
+            get playing() {
+                return playingRef.current;
+            },
+            get videoElement() {
+                // No <video> here. The caller is the beat-rate effect in
+                // CenterColumn — it reads currentTime / sets playbackRate
+                // and listens for `timeupdate`. We don't synthesize that
+                // event; beat-mode playback-rate adjustment is a known gap
+                // for the prototype (see SNAPPY_PLAYER_NOTES.md).
+                return null;
+            },
+        }),
+        [duration, paintNearest, requestWindow, startTicking, stopTicking],
+    );
+
+    return (
+        <div className="video-player video-player--snappy">
+            <canvas ref={canvasRef} className="video-player__canvas" />
+            <audio ref={audioRef} src={audioUrl} preload="auto" />
+            {status === "error" && (
+                <div className="video-player__error" title={error ?? ""}>
+                    decode error
+                </div>
+            )}
+            {status === "decoding" && cacheRef.current.length === 0 && (
+                <div className="video-player__decoding">decoding…</div>
+            )}
+        </div>
+    );
+});
+
+/** In-place insert into a pts-sorted array. Streams arrive in order, so the
+ *  common case is `push`; the fall-back binary-insert keeps things tidy if a
+ *  reorder ever slips through. */
+function insertSorted(arr: CachedFrame[], frame: CachedFrame) {
+    if (arr.length === 0 || arr[arr.length - 1].pts <= frame.pts) {
+        arr.push(frame);
+        return;
+    }
+    let lo = 0;
+    let hi = arr.length;
+    while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (arr[mid].pts < frame.pts) lo = mid + 1;
+        else hi = mid;
+    }
+    arr.splice(lo, 0, frame);
+}

--- a/src/components/SnappyVideoPlayer.tsx
+++ b/src/components/SnappyVideoPlayer.tsx
@@ -34,13 +34,22 @@ interface SnappyVideoPlayerProps {
     fps: number;
     /** `convertFileSrc(path)` — only used by the sibling `<audio>` element. */
     audioUrl: string;
-    /** Optional rate-at-time callback. Called once per animation frame with
-     *  the current media time; the cache walker advances by `wall_elapsed *
-     *  getRate(t)` and the audio element tracks the same rate. Used for
-     *  beat-time playback, where the rate varies along an orig→beat anchor
-     *  map. When omitted, the imperative `setPlaybackRate` value is used as
-     *  a constant rate. */
-    getRate?: (mediaTime: number) => number;
+    /** Optional **direct** wall→source projection. Given the source time
+     *  the playhead was anchored at (last play/seek) and the wall-clock
+     *  seconds elapsed since that anchor, return the source time the
+     *  canvas should be showing **right now**. Called once per animation
+     *  frame.
+     *
+     *  This is the "frame-perfect" entry point: in beat mode the caller
+     *  inverts the warp so the displayed source frame is exactly where it
+     *  should sit on the wall clock, with no per-frame rate-times-dt
+     *  integration drift across segment boundaries. The local playback
+     *  rate (needed by the `<audio>` element) is recovered numerically
+     *  from the slope of consecutive samples.
+     *
+     *  When omitted, the imperative `setPlaybackRate` value is applied as
+     *  a constant rate: `source = anchor + rate * wallElapsed`. */
+    mapWallToSource?: (anchorSource: number, wallElapsed: number) => number;
     onTimeUpdate?: (time: number) => void;
     onPlayStateChange?: (playing: boolean) => void;
 }
@@ -61,7 +70,7 @@ interface CachedFrame {
 }
 
 export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function SnappyVideoPlayer(
-    { path, duration, fps, audioUrl, getRate, onTimeUpdate, onPlayStateChange },
+    { path, duration, fps, audioUrl, mapWallToSource, onTimeUpdate, onPlayStateChange },
     ref,
 ) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -79,19 +88,28 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
     }>({ seq: 0, id: null, start: 0, end: 0 });
     const playingRef = useRef(false);
     const currentTimeRef = useRef(0);
+    /** Fallback playback rate used when `mapWallToSource` is not supplied —
+     *  set imperatively via `setPlaybackRate(rate)` from the Toolbar. */
     const playbackRateRef = useRef(1);
-    // Wall-clock anchor for the cache-walker loop: when we last advanced the
-    // playhead during playback, what (wall, media) pair did we use?
-    const playClockRef = useRef<{ wall: number; media: number } | null>(null);
+    /** Playback anchor: where the playhead sat (`source`) on the wall clock
+     *  (`wall`) the last time the user pressed play, seeked, or resumed.
+     *  Every tick computes `source = mapWallToSource(anchor.source, now -
+     *  anchor.wall)`, so there is **zero** per-frame integration of
+     *  rate × dt — segment boundaries don't drift. */
+    const playClockRef = useRef<{ wall: number; source: number } | null>(null);
+    /** Last (wall, source) we sampled in `tick`. Used to recover the local
+     *  playback rate as a numerical slope and feed it to the audio element
+     *  so the pitched audio tracks the visual warp. */
+    const lastSampleRef = useRef<{ wall: number; source: number } | null>(null);
     const rafRef = useRef<number | null>(null);
     const onTimeUpdateRef = useRef(onTimeUpdate);
     onTimeUpdateRef.current = onTimeUpdate;
     const onPlayStateChangeRef = useRef(onPlayStateChange);
     onPlayStateChangeRef.current = onPlayStateChange;
-    // Rate callback lives in a ref so updates don't re-render or invalidate
-    // the memoised tick. The cache walker reads the latest value each frame.
-    const getRateRef = useRef(getRate);
-    getRateRef.current = getRate;
+    // Projection callback lives in a ref so updates don't re-render or
+    // invalidate the memoised tick. Read on every animation frame.
+    const mapWallToSourceRef = useRef(mapWallToSource);
+    mapWallToSourceRef.current = mapWallToSource;
 
     const [status, setStatus] = useState<"idle" | "decoding" | "ready" | "error">("idle");
     const [error, setError] = useState<string | null>(null);
@@ -249,6 +267,23 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
     }, [path, clearCache, requestWindow]);
 
     // ── Playback loop ────────────────────────────────────────────────────────
+    //
+    // Frame-perfect timing model:
+    //
+    //   source(wall_now) = mapWallToSource(anchor.source, wall_now - anchor.wall)
+    //
+    // The projection is evaluated **directly** every animation frame — we
+    // never integrate `rate * dt` across ticks, so there is no error
+    // accumulation as the warp crosses segment boundaries. The anchor is
+    // only updated on play / seek / resume; while playing, the closed-form
+    // projection is the single source of truth for "what source frame
+    // should be on screen right now".
+    //
+    // The audio element wants an instantaneous playback rate (it can't
+    // re-project an entire media clock per frame), so we recover the local
+    // rate as the numerical slope between the previous and current
+    // projection samples — naturally tracks the warp through every
+    // segment and audio stays pitched-in-sync with the visual.
 
     const tick = useCallback(() => {
         if (!playingRef.current) {
@@ -258,32 +293,35 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
         const now = performance.now() / 1000;
         const clock = playClockRef.current;
         if (clock) {
-            // Variable-rate playback: re-evaluate the effective rate at the
-            // current media time on every frame so beat-warped playback
-            // (where the rate changes piecewise along the anchor map) stays
-            // accurate without overshooting at segment boundaries. The
-            // browser clamp on HTMLMediaElement.playbackRate is 0.0625–16;
-            // mirror that here so the wall-clock estimate and the audio
-            // element agree.
-            const rawRate = getRateRef.current?.(currentTimeRef.current) ?? playbackRateRef.current;
-            const rate = Math.max(0.0625, Math.min(16, rawRate));
-            const elapsed = (now - clock.wall) * rate;
-            const next = Math.min(duration, clock.media + elapsed);
-            // Re-anchor every frame. With a constant rate this is a no-op
-            // (next - media == elapsed); with a variable rate it stops the
-            // formula from compounding stale-rate × stale-elapsed across
-            // segment boundaries.
-            clock.wall = now;
-            clock.media = next;
+            const elapsed = now - clock.wall;
+            const projected =
+                mapWallToSourceRef.current?.(clock.source, elapsed) ??
+                clock.source + elapsed * playbackRateRef.current;
+            const next = Math.max(0, Math.min(duration, projected));
             currentTimeRef.current = next;
             paintNearest(next);
             onTimeUpdateRef.current?.(next);
-            // Keep the audio element matched to the same rate so the
-            // pitched-up/down audio stays in sync with the visual clock.
-            // Setting playbackRate every frame is cheap and idempotent.
-            if (audioRef.current && audioRef.current.playbackRate !== rate) {
-                audioRef.current.playbackRate = rate;
+
+            // Audio rate = local slope d(source)/d(wall). Reuses the
+            // already-projected `next` rather than re-evaluating the map at
+            // (now + ε), which would double the projection cost per frame
+            // for no extra accuracy. Falls back to the fallback constant
+            // rate before we've sampled at least one prior frame.
+            const last = lastSampleRef.current;
+            if (audioRef.current) {
+                let localRate = playbackRateRef.current;
+                if (last && now > last.wall) {
+                    localRate = (next - last.source) / (now - last.wall);
+                }
+                // HTMLMediaElement clamps to 0.0625–16; mirror that explicitly
+                // so the assignment is idempotent across browsers.
+                const clamped = Math.max(0.0625, Math.min(16, localRate || 1));
+                if (Math.abs(audioRef.current.playbackRate - clamped) > 1e-3) {
+                    audioRef.current.playbackRate = clamped;
+                }
             }
+            lastSampleRef.current = { wall: now, source: next };
+
             if (next >= duration - 1e-4) {
                 playingRef.current = false;
                 onPlayStateChangeRef.current?.(false);
@@ -299,10 +337,9 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
     }, [duration, paintNearest, requestWindow]);
 
     const startTicking = useCallback(() => {
-        playClockRef.current = {
-            wall: performance.now() / 1000,
-            media: currentTimeRef.current,
-        };
+        const wall = performance.now() / 1000;
+        playClockRef.current = { wall, source: currentTimeRef.current };
+        lastSampleRef.current = { wall, source: currentTimeRef.current };
         if (rafRef.current === null) rafRef.current = requestAnimationFrame(tick);
     }, [tick]);
 
@@ -312,6 +349,7 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
             rafRef.current = null;
         }
         playClockRef.current = null;
+        lastSampleRef.current = null;
     }, []);
 
     useEffect(() => {
@@ -343,10 +381,9 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
                 // jump forward by however long the last wall-clock interval
                 // was.
                 if (playingRef.current) {
-                    playClockRef.current = {
-                        wall: performance.now() / 1000,
-                        media: clamped,
-                    };
+                    const wall = performance.now() / 1000;
+                    playClockRef.current = { wall, source: clamped };
+                    lastSampleRef.current = { wall, source: clamped };
                 }
             },
             play() {
@@ -377,14 +414,18 @@ export default forwardRef<VideoPlayerHandle, SnappyVideoPlayerProps>(function Sn
                 }
             },
             setPlaybackRate(rate: number) {
+                // Fallback constant rate, used only when no `mapWallToSource`
+                // is supplied. When one is supplied, the projection captures
+                // the speed multiplier itself and this is ignored.
                 playbackRateRef.current = rate;
                 if (audioRef.current) audioRef.current.playbackRate = rate;
-                // Re-anchor so the new rate applies from "now", not retroactively.
                 if (playingRef.current) {
-                    playClockRef.current = {
-                        wall: performance.now() / 1000,
-                        media: currentTimeRef.current,
-                    };
+                    // Re-anchor so the new rate applies from "now", not
+                    // retroactively. With a projection in place, the new
+                    // speed shows up at the next tick via the supplied map.
+                    const wall = performance.now() / 1000;
+                    playClockRef.current = { wall, source: currentTimeRef.current };
+                    lastSampleRef.current = { wall, source: currentTimeRef.current };
                 }
             },
             get currentTime() {

--- a/src/components/VideoPlayer.css
+++ b/src/components/VideoPlayer.css
@@ -14,3 +14,35 @@
     display: block;
     object-fit: contain;
 }
+
+.video-player--snappy {
+    position: relative;
+}
+
+.video-player__canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: contain;
+    background: #000;
+}
+
+.video-player__error,
+.video-player__decoding {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    font-size: 11px;
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+    pointer-events: none;
+}
+
+.video-player__error {
+    color: #ff6b6b;
+}

--- a/src/layout/CenterColumn.tsx
+++ b/src/layout/CenterColumn.tsx
@@ -43,7 +43,13 @@ import {
 } from "../store/slices/sceneSlice";
 import { setListSelection, setPendingEdit } from "../store/slices/listsSlice";
 import { calcZoomToRegion } from "../utils/view";
-import { beatRateAt } from "../timeline/model/beatMap";
+import {
+    beatRateAt,
+    beatToOrig,
+    buildAnchorPairs,
+    origToBeat,
+    type AnchorPair,
+} from "../timeline/model/beatMap";
 import { calcNewRegionBoundsFromScenes } from "../timeline/model/newRegionBounds";
 import { findPreviousTarget } from "../utils/navigation";
 import { visibleSceneCuts } from "../utils/sceneFilter";
@@ -177,17 +183,50 @@ export default function CenterColumn() {
     // Tracks the speed-dropdown multiplier set in Toolbar (default 1×).
     const speedRef = useRef(1);
 
+    // Anchor pairs are derived from origAnchors + beatAnchors; memoise so
+    // the snappy player's per-frame projection doesn't re-sort the lists on
+    // every animation tick (with thousands of markers this would dominate).
+    const anchorPairs = useMemo(
+        () => buildAnchorPairs(origAnchors, beatAnchors),
+        [origAnchors, beatAnchors],
+    );
+    const anchorPairsRef = useRef<AnchorPair[]>(anchorPairs);
+    anchorPairsRef.current = anchorPairs;
+
     // The single source of truth for "what rate should playback advance at
     // right now". Beat mode walks the orig→beat anchor map (per-segment
-    // linear slope); orig mode is the dropdown multiplier directly. Both
-    // players (HTML5 and snappy) consume this same function so they warp
-    // identically.
+    // linear slope); orig mode is the dropdown multiplier directly. Used
+    // by the HTML5 path's `timeupdate` handler.
     const getEffectiveRate = useCallback((mediaTime: number): number => {
         const dropdownSpeed = speedRef.current;
         if (playbackModeRef.current !== "beat") return dropdownSpeed;
         return (
             beatRateAt(mediaTime, origAnchorsRef.current, beatAnchorsRef.current) * dropdownSpeed
         );
+    }, []);
+
+    // Closed-form wall→source projection for the snappy player. The cache
+    // walker evaluates this once per animation frame to figure out exactly
+    // which source frame should be on screen — no per-tick rate × dt
+    // integration, so the result is frame-perfect at segment boundaries.
+    //
+    //   orig mode: source = anchor + speed * elapsed
+    //   beat mode: source = beatToOrig(origToBeat(anchor) + speed * elapsed)
+    //
+    // where `elapsed` is wall-clock seconds since the player anchored
+    // (last play / seek / resume / rate change). Speed is the toolbar
+    // dropdown multiplier (1× by default). When beat anchors don't cover
+    // the current time, `beatToOrig`/`origToBeat` are identity, so this
+    // gracefully degrades to orig-mode behaviour.
+    const mapWallToSource = useCallback((anchorSource: number, wallElapsed: number): number => {
+        const dropdownSpeed = speedRef.current;
+        if (playbackModeRef.current !== "beat") {
+            return anchorSource + dropdownSpeed * wallElapsed;
+        }
+        const pairs = anchorPairsRef.current;
+        if (pairs.length < 2) return anchorSource + dropdownSpeed * wallElapsed;
+        const beatStart = origToBeat(anchorSource, pairs);
+        return beatToOrig(beatStart + dropdownSpeed * wallElapsed, pairs);
     }, []);
 
     useEffect(() => {
@@ -325,7 +364,7 @@ export default function CenterColumn() {
                             duration={video.duration}
                             fps={video.fps}
                             audioUrl={video.videoUrl}
-                            getRate={getEffectiveRate}
+                            mapWallToSource={mapWallToSource}
                             onTimeUpdate={(t) => {
                                 if (playbackLoopMode !== "continue" && playing) {
                                     const inPoint = activeRegion?.inPoint ?? 0;

--- a/src/layout/CenterColumn.tsx
+++ b/src/layout/CenterColumn.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import VideoPlayer from "../components/VideoPlayer";
+import SnappyVideoPlayer from "../components/SnappyVideoPlayer";
 import Filmstrip from "../components/Filmstrip";
 import WarpView from "../components/WarpView";
 import Toolbar from "../components/Toolbar";
@@ -76,6 +77,7 @@ export default function CenterColumn() {
     const playbackLoopMode = useAppSelector((s) => s.ui.playbackLoopMode);
     const view = useAppSelector((s) => s.ui.view);
     const timelineHeight = useAppSelector((s) => s.ui.timelineHeight);
+    const snappyPlayer = useAppSelector((s) => s.settings.snappyPlayer);
 
     const warpData = useAppSelector(selectWarpData);
     const origAnchors = useAppSelector((s) => s.warp.origAnchors);
@@ -336,36 +338,65 @@ export default function CenterColumn() {
             </div>
             <div className="vj-player">
                 <div className="vj-player__video">
-                    <VideoPlayer
-                        ref={playerRef}
-                        src={video.videoUrl}
-                        duration={video.duration}
-                        onTimeUpdate={(t) => {
-                            // Apply the playback loop mode at the active region's outPoint
-                            // (or video duration when no region is active). The HTML5 video
-                            // element keeps rolling past the end on its own — we intercept
-                            // here, *before* publishing the playhead, so the timeline
-                            // doesn't overshoot the boundary even for a frame.
-                            if (playbackLoopMode !== "continue" && playing) {
-                                const inPoint = activeRegion?.inPoint ?? 0;
-                                const outPoint = activeRegion?.outPoint ?? video.duration;
-                                if (t >= outPoint - 0.001 && outPoint > inPoint) {
-                                    if (playbackLoopMode === "loop") {
-                                        playerRef.current?.seek(inPoint);
-                                        dispatch(setPlayheadAction(inPoint));
+                    {snappyPlayer ? (
+                        <SnappyVideoPlayer
+                            ref={playerRef}
+                            path={video.path}
+                            duration={video.duration}
+                            fps={video.fps}
+                            audioUrl={video.videoUrl}
+                            onTimeUpdate={(t) => {
+                                if (playbackLoopMode !== "continue" && playing) {
+                                    const inPoint = activeRegion?.inPoint ?? 0;
+                                    const outPoint = activeRegion?.outPoint ?? video.duration;
+                                    if (t >= outPoint - 0.001 && outPoint > inPoint) {
+                                        if (playbackLoopMode === "loop") {
+                                            playerRef.current?.seek(inPoint);
+                                            dispatch(setPlayheadAction(inPoint));
+                                            return;
+                                        }
+                                        playerRef.current?.pause();
+                                        playerRef.current?.seek(outPoint);
+                                        dispatch(setPlayheadAction(outPoint));
                                         return;
                                     }
-                                    // 'stop' — pause at the boundary, snap the playhead exactly.
-                                    playerRef.current?.pause();
-                                    playerRef.current?.seek(outPoint);
-                                    dispatch(setPlayheadAction(outPoint));
-                                    return;
                                 }
-                            }
-                            dispatch(setPlayheadAction(t));
-                        }}
-                        onPlayStateChange={(v) => dispatch(setPlayingAction(v))}
-                    />
+                                dispatch(setPlayheadAction(t));
+                            }}
+                            onPlayStateChange={(v) => dispatch(setPlayingAction(v))}
+                        />
+                    ) : (
+                        <VideoPlayer
+                            ref={playerRef}
+                            src={video.videoUrl}
+                            duration={video.duration}
+                            onTimeUpdate={(t) => {
+                                // Apply the playback loop mode at the active region's outPoint
+                                // (or video duration when no region is active). The HTML5 video
+                                // element keeps rolling past the end on its own — we intercept
+                                // here, *before* publishing the playhead, so the timeline
+                                // doesn't overshoot the boundary even for a frame.
+                                if (playbackLoopMode !== "continue" && playing) {
+                                    const inPoint = activeRegion?.inPoint ?? 0;
+                                    const outPoint = activeRegion?.outPoint ?? video.duration;
+                                    if (t >= outPoint - 0.001 && outPoint > inPoint) {
+                                        if (playbackLoopMode === "loop") {
+                                            playerRef.current?.seek(inPoint);
+                                            dispatch(setPlayheadAction(inPoint));
+                                            return;
+                                        }
+                                        // 'stop' — pause at the boundary, snap the playhead exactly.
+                                        playerRef.current?.pause();
+                                        playerRef.current?.seek(outPoint);
+                                        dispatch(setPlayheadAction(outPoint));
+                                        return;
+                                    }
+                                }
+                                dispatch(setPlayheadAction(t));
+                            }}
+                            onPlayStateChange={(v) => dispatch(setPlayingAction(v))}
+                        />
+                    )}
                 </div>
                 <Filmstrip
                     onSeekFrame={(frame) => {

--- a/src/layout/CenterColumn.tsx
+++ b/src/layout/CenterColumn.tsx
@@ -43,6 +43,7 @@ import {
 } from "../store/slices/sceneSlice";
 import { setListSelection, setPendingEdit } from "../store/slices/listsSlice";
 import { calcZoomToRegion } from "../utils/view";
+import { beatRateAt } from "../timeline/model/beatMap";
 import { calcNewRegionBoundsFromScenes } from "../timeline/model/newRegionBounds";
 import { findPreviousTarget } from "../utils/navigation";
 import { visibleSceneCuts } from "../utils/sceneFilter";
@@ -176,61 +177,40 @@ export default function CenterColumn() {
     // Tracks the speed-dropdown multiplier set in Toolbar (default 1×).
     const speedRef = useRef(1);
 
-    useEffect(() => {
-        /** Given the sorted orig/beat anchor arrays and the current video time,
-         *  return the playbackRate that makes beat-time advance at 1×.
-         *  Returns 1 when outside the anchor range or when < 2 anchors exist. */
-        function computeBeatRate(currentTime: number): number {
-            const oAnchors = origAnchorsRef.current;
-            const bAnchors = beatAnchorsRef.current;
-            if (oAnchors.length < 2) return 1;
-            // Build sorted pairs
-            const sorted = [...oAnchors]
-                .sort((a, b) => a.time - b.time)
-                .map((oa) => {
-                    const ba = bAnchors.find((b) => b.id === oa.id);
-                    return { origTime: oa.time, beatTime: ba ? ba.time : oa.time };
-                });
-            // Find the segment containing currentTime
-            for (let i = 0; i < sorted.length - 1; i++) {
-                const o0 = sorted[i].origTime;
-                const o1 = sorted[i + 1].origTime;
-                if (currentTime >= o0 && currentTime <= o1) {
-                    const origSpan = o1 - o0;
-                    const beatSpan = sorted[i + 1].beatTime - sorted[i].beatTime;
-                    if (beatSpan <= 0 || origSpan <= 0) return 1;
-                    // rate = origSpan / beatSpan → beat advances 1s per 1s of wall-clock
-                    return origSpan / beatSpan;
-                }
-            }
-            return 1; // outside anchor range
-        }
+    // The single source of truth for "what rate should playback advance at
+    // right now". Beat mode walks the orig→beat anchor map (per-segment
+    // linear slope); orig mode is the dropdown multiplier directly. Both
+    // players (HTML5 and snappy) consume this same function so they warp
+    // identically.
+    const getEffectiveRate = useCallback((mediaTime: number): number => {
+        const dropdownSpeed = speedRef.current;
+        if (playbackModeRef.current !== "beat") return dropdownSpeed;
+        return (
+            beatRateAt(mediaTime, origAnchorsRef.current, beatAnchorsRef.current) * dropdownSpeed
+        );
+    }, []);
 
+    useEffect(() => {
         const v = playerRef.current?.videoElement;
         if (!v) return;
 
+        // HTML5 path: drive the rate from `timeupdate` events on the
+        // underlying <video>. Browser clamp on playbackRate is 0.0625–16.
         const handleTimeUpdate = () => {
-            const dropdownSpeed = speedRef.current;
-            if (playbackModeRef.current === "beat") {
-                const beatRate = computeBeatRate(v.currentTime) * dropdownSpeed;
-                // Clamp to browser-supported range (most browsers: 0.0625–16)
-                v.playbackRate = Math.max(0.0625, Math.min(16, beatRate));
-            } else {
-                if (v.playbackRate !== dropdownSpeed) v.playbackRate = dropdownSpeed;
-            }
+            const rate = Math.max(0.0625, Math.min(16, getEffectiveRate(v.currentTime)));
+            if (v.playbackRate !== rate) v.playbackRate = rate;
         };
 
         v.addEventListener("timeupdate", handleTimeUpdate);
-        // Apply immediately in case mode changes while paused
         handleTimeUpdate();
         return () => {
             v.removeEventListener("timeupdate", handleTimeUpdate);
-            // Restore native rate when effect is cleaned up
             if (v.playbackRate !== 1) v.playbackRate = 1;
         };
-        // Re-attach whenever the video element changes (new src load) or mode changes.
-        // Anchor changes are picked up via refs — no need to re-run the effect.
-    }, [playerRef, playbackMode, video?.path]);
+        // Re-attach when the underlying <video> element changes (new src
+        // load) or when the player implementation swaps. Anchor + mode
+        // changes are picked up through refs.
+    }, [playerRef, playbackMode, video?.path, getEffectiveRate]);
 
     // ── Empty / loading state ─────────────────────────────────────────────────
     // Rendered in the center slot whenever there's no usable video, so the
@@ -345,6 +325,7 @@ export default function CenterColumn() {
                             duration={video.duration}
                             fps={video.fps}
                             audioUrl={video.videoUrl}
+                            getRate={getEffectiveRate}
                             onTimeUpdate={(t) => {
                                 if (playbackLoopMode !== "continue" && playing) {
                                     const inPoint = activeRegion?.inPoint ?? 0;

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -36,6 +36,10 @@ interface SettingsState {
     geminiModel: string;
     /** Lerp-animate the timeline view window when scrolling/panning. */
     smoothPan: boolean;
+    /** Experimental: replace the HTML5 `<video>` element with an ffmpeg-fed
+     *  canvas player for snappier scrub. Audio is best-effort; see
+     *  docs/SNAPPY_PLAYER_NOTES.md for known gaps. */
+    snappyPlayer: boolean;
 }
 
 const DEFAULTS: SettingsState = {
@@ -47,6 +51,7 @@ const DEFAULTS: SettingsState = {
     geminiApiKey: "",
     geminiModel: "gemini-2.5-flash",
     smoothPan: true,
+    snappyPlayer: false,
 };
 
 const STORAGE_KEY = "lockstep.settings.v1";
@@ -86,6 +91,10 @@ function loadFromStorage(): SettingsState {
                     : DEFAULTS.geminiModel,
             smoothPan:
                 typeof parsed.smoothPan === "boolean" ? parsed.smoothPan : DEFAULTS.smoothPan,
+            snappyPlayer:
+                typeof parsed.snappyPlayer === "boolean"
+                    ? parsed.snappyPlayer
+                    : DEFAULTS.snappyPlayer,
         };
     } catch {
         return DEFAULTS;
@@ -136,6 +145,10 @@ const settingsSlice = createSlice({
             state.smoothPan = action.payload;
             saveToStorage(state);
         },
+        setSnappyPlayer(state, action: PayloadAction<boolean>) {
+            state.snappyPlayer = action.payload;
+            saveToStorage(state);
+        },
         resetSettings(state) {
             state.thumbWidth = DEFAULTS.thumbWidth;
             state.maxCachedFrames = DEFAULTS.maxCachedFrames;
@@ -157,6 +170,7 @@ export const {
     setGeminiApiKey,
     setGeminiModel,
     setSmoothPan,
+    setSnappyPlayer,
     resetSettings,
 } = settingsSlice.actions;
 export default settingsSlice.reducer;

--- a/src/timeline/model/beatMap.ts
+++ b/src/timeline/model/beatMap.ts
@@ -89,3 +89,29 @@ export function anchorBeatAt(
     const b = beatAnchors.find((b) => b.id === a.id);
     return b?.time;
 }
+
+/**
+ * Local playback rate that makes beat-time advance at 1× given the source
+ * time. In each segment between two anchor pairs the warp is linear, so the
+ * rate is the slope `origSpan / beatSpan` — playing the source that fast
+ * makes one second of beat-time elapse per wall-clock second. Returns 1
+ * outside the covered range or when fewer than two pairs exist.
+ *
+ * Used by the playback rate effect in CenterColumn (HTML5 path) and by the
+ * snappy player's cache walker (canvas path) so both players warp identically.
+ */
+export function beatRateAt(time: number, anchors: Anchor[], beatAnchors: Anchor[]): number {
+    if (anchors.length < 2) return 1;
+    const pairs = buildAnchorPairs(anchors, beatAnchors);
+    for (let i = 0; i < pairs.length - 1; i++) {
+        const o0 = pairs[i].inT;
+        const o1 = pairs[i + 1].inT;
+        if (time >= o0 && time <= o1) {
+            const origSpan = o1 - o0;
+            const beatSpan = pairs[i + 1].outT - pairs[i].outT;
+            if (beatSpan <= 0 || origSpan <= 0) return 1;
+            return origSpan / beatSpan;
+        }
+    }
+    return 1;
+}

--- a/tests/unit/timeline/model/beatMap.test.ts
+++ b/tests/unit/timeline/model/beatMap.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
     anchorBeatAt,
     beatRateAt,
+    beatToOrig,
     buildAnchorPairs,
     origToBeat,
 } from "../../../../src/timeline/model/beatMap";
@@ -134,5 +135,89 @@ describe("beatRateAt", () => {
             { id: 2, time: 1 },
         ];
         expect(beatRateAt(5, a, b)).toBe(1);
+    });
+});
+
+/** Helper: simulate the snappy player's per-frame wall→source projection.
+ *  Mirrors `mapWallToSource` in `CenterColumn.tsx` so the test exercises the
+ *  exact same composition (`origToBeat → +elapsed → beatToOrig`) the player
+ *  uses each animation frame. */
+function mapWallToSource(
+    anchorSource: number,
+    wallElapsed: number,
+    pairs: ReturnType<typeof buildAnchorPairs>,
+): number {
+    if (pairs.length < 2) return anchorSource + wallElapsed;
+    return beatToOrig(origToBeat(anchorSource, pairs) + wallElapsed, pairs);
+}
+
+describe("frame-perfect projection (wall → source in beat mode)", () => {
+    // Two-segment warp:
+    //   segment A: source [0..10] → beat [0..5]   (source plays at 2× to make
+    //                                              beat 1×; rate = 10/5 = 2)
+    //   segment B: source [10..20] → beat [5..20] (source plays at 0.667×;
+    //                                              rate = 10/15)
+    // A boundary crossing at source=10 means the local rate jumps abruptly.
+    const orig: Anchor[] = [
+        { id: 1, time: 0 },
+        { id: 2, time: 10 },
+        { id: 3, time: 20 },
+    ];
+    const beat: Anchor[] = [
+        { id: 1, time: 0 },
+        { id: 2, time: 5 },
+        { id: 3, time: 20 },
+    ];
+    const pairs = buildAnchorPairs(orig, beat);
+
+    it("crosses a segment boundary frame-perfectly", () => {
+        // Start at source=8 inside segment A (rate 2×). Project forward 4
+        // wall-clock seconds. Beat advances 4: 4→8. 8 lies inside segment B,
+        // so source-end = beatToOrig(8) = 10 + (8-5)/(20-5)*(20-10) = 12.
+        // The OLD integration approach would have rounded to whichever side
+        // of source=10 the rate switch landed on, leaking a fraction of a
+        // frame; the direct projection lands on 12 exactly.
+        expect(mapWallToSource(8, 4, pairs)).toBe(12);
+    });
+
+    it("matches the integrated rate inside a single segment", () => {
+        // Same answer as `anchor + rate * dt` when the entire interval stays
+        // in one segment — sanity-check that the new path doesn't introduce
+        // drift for the easy case.
+        const dt = 1.5;
+        const rate = 2; // segment A
+        const projected = mapWallToSource(2, dt, pairs);
+        const integrated = 2 + rate * dt;
+        expect(projected).toBeCloseTo(integrated, 12);
+    });
+
+    it("recovers the local audio rate as the numerical slope", () => {
+        // The player's tick computes `localRate = (next - last) / wall_dt`
+        // and feeds it to the <audio> element. Verify the slope matches
+        // beatRateAt at the sample point on both sides of the segment edge.
+        const eps = 1e-5;
+        const sourceInA = 6;
+        const sourceInB = 14;
+        const slopeA = (mapWallToSource(sourceInA, eps, pairs) - sourceInA) / eps;
+        const slopeB = (mapWallToSource(sourceInB, eps, pairs) - sourceInB) / eps;
+        expect(slopeA).toBeCloseTo(beatRateAt(sourceInA, orig, beat), 4);
+        expect(slopeB).toBeCloseTo(beatRateAt(sourceInB, orig, beat), 4);
+    });
+
+    it("is monotonic non-decreasing across the boundary", () => {
+        // Walk 200 ms in 5 ms steps from before to after the boundary; the
+        // source position must never go backwards (it has to be a valid
+        // playback trajectory for the cache walker to paint sensibly).
+        let prev = -Infinity;
+        for (let dt = 0; dt <= 0.2; dt += 0.005) {
+            const s = mapWallToSource(9.5, dt, pairs);
+            expect(s).toBeGreaterThanOrEqual(prev);
+            prev = s;
+        }
+    });
+
+    it("degrades to identity with fewer than two anchor pairs", () => {
+        const empty = buildAnchorPairs([], []);
+        expect(mapWallToSource(7, 3, empty)).toBe(10);
     });
 });

--- a/tests/unit/timeline/model/beatMap.test.ts
+++ b/tests/unit/timeline/model/beatMap.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildAnchorPairs, origToBeat, anchorBeatAt } from "../../../../src/timeline/model/beatMap";
+import {
+    anchorBeatAt,
+    beatRateAt,
+    buildAnchorPairs,
+    origToBeat,
+} from "../../../../src/timeline/model/beatMap";
 import type { Anchor } from "../../../../src/types";
 
 describe("buildAnchorPairs", () => {
@@ -87,5 +92,47 @@ describe("anchorBeatAt", () => {
 
     it("returns undefined when the anchor has no beat pair", () => {
         expect(anchorBeatAt(10, anchors, [])).toBeUndefined();
+    });
+});
+
+describe("beatRateAt", () => {
+    // Two segments: [0..10] orig stretches to [0..5] beat (2× faster than beat),
+    // [10..20] orig stretches to [5..20] beat (1.5× slower than beat).
+    const anchors: Anchor[] = [
+        { id: 1, time: 0 },
+        { id: 2, time: 10 },
+        { id: 3, time: 20 },
+    ];
+    const beatAnchors: Anchor[] = [
+        { id: 1, time: 0 },
+        { id: 2, time: 5 },
+        { id: 3, time: 20 },
+    ];
+
+    it("returns origSpan / beatSpan inside each segment", () => {
+        expect(beatRateAt(5, anchors, beatAnchors)).toBe(2);
+        expect(beatRateAt(15, anchors, beatAnchors)).toBeCloseTo(10 / 15);
+    });
+
+    it("returns 1 outside the anchor range", () => {
+        expect(beatRateAt(-1, anchors, beatAnchors)).toBe(1);
+        expect(beatRateAt(25, anchors, beatAnchors)).toBe(1);
+    });
+
+    it("returns 1 with fewer than two anchors", () => {
+        expect(beatRateAt(5, [], [])).toBe(1);
+        expect(beatRateAt(5, [{ id: 1, time: 0 }], [{ id: 1, time: 0 }])).toBe(1);
+    });
+
+    it("returns 1 on a degenerate zero-length segment", () => {
+        const a: Anchor[] = [
+            { id: 1, time: 5 },
+            { id: 2, time: 5 },
+        ];
+        const b: Anchor[] = [
+            { id: 1, time: 0 },
+            { id: 2, time: 1 },
+        ];
+        expect(beatRateAt(5, a, b)).toBe(1);
     });
 });


### PR DESCRIPTION
A new SnappyVideoPlayer renders frames to a 2D canvas instead of an HTML5
<video> element. Frames come from a Rust-side ffmpeg subprocess that pipes
MJPEG over a per-invocation Tauri Channel<InvokeResponseBody> as raw bytes
(no base64, no JSON) — a 16-byte little-endian header carries index + pts +
jpeg length, the rest is the JPEG payload.

The frontend keeps a pts-sorted ring buffer of decoded ImageBitmaps around
the playhead (~6 s window by default) and paints the nearest cached frame
on every seek or animation tick, so scrub inside the cached window is
instantaneous. The window is reprefetched when the playhead nears either
edge; superseded streams are cancelled but their cached frames are kept
until they fall outside the new window (avoids the black-flash on
reposition).

Toggle in Settings → Snappy player (experimental). Audio is a sibling
<audio> element with best-effort resync on seek; beat-time playback rate
is not yet wired up. Both gaps + tuning knobs documented in
docs/SNAPPY_PLAYER_NOTES.md.

https://claude.ai/code/session_01QzFDxvTfVUHafW4uGJci5W